### PR TITLE
Allow shader modules to register uniforms

### DIFF
--- a/packages/vfx/src/shaders/composableShader.ts
+++ b/packages/vfx/src/shaders/composableShader.ts
@@ -23,38 +23,42 @@ export const formatValue = (value: any) =>
   typeof value === "number" ? value.toFixed(5) : value
 
 export const composableShader = () => {
-  const state = {
-    vertexHeaders: new Array<string>(),
-    vertexMain: new Array<string>(),
-    fragmentHeaders: new Array<string>(),
-    fragmentMain: new Array<string>()
+  const modules = new Array<Module>()
+
+  function addModule(module: Module) {
+    modules.push(module)
   }
 
-  const addModule = (module: Module) => {
-    state.vertexHeaders.push(module.vertexHeader)
-    state.vertexMain.push(`{ ${module.vertexMain} }`)
-    state.fragmentHeaders.push(module.fragmentHeader)
-    state.fragmentMain.push(`{ ${module.fragmentMain} }`)
+  function compileProgram(headers: string[], main: string[]) {
+    return `
+      ${headers.join("\n\n")}
+      void main() {
+        ${main.join("\n\n")}
+      }
+    `
   }
 
-  const compileProgram = (headers: string[], main: string[]) => `
-    ${headers.join("\n\n")}
-    void main() {
-      ${main.join("\n\n")}
-    }
-  `
+  function compile() {
+    return {
+      vertexShader: compileProgram(
+        modules.map((m) => m.vertexHeader),
+        modules.map((m) => `{ ${m.vertexMain} }`)
+      ),
 
-  const compile = () => ({
-    vertexShader: compileProgram(state.vertexHeaders, state.vertexMain),
-    fragmentShader: compileProgram(state.fragmentHeaders, state.fragmentMain),
-    uniforms: {
-      u_time: { value: 0 },
-      u_depth: { value: null },
-      u_cameraNear: { value: 0 },
-      u_cameraFar: { value: 1 },
-      u_resolution: { value: [window.innerWidth, window.innerHeight] }
+      fragmentShader: compileProgram(
+        modules.map((m) => m.fragmentHeader),
+        modules.map((m) => `{ ${m.fragmentMain} }`)
+      ),
+
+      uniforms: {
+        u_time: { value: 0 },
+        u_depth: { value: null },
+        u_cameraNear: { value: 0 },
+        u_cameraFar: { value: 1 },
+        u_resolution: { value: [window.innerWidth, window.innerHeight] }
+      }
     }
-  })
+  }
 
   return { addModule, compile }
 }

--- a/packages/vfx/src/shaders/composableShader.ts
+++ b/packages/vfx/src/shaders/composableShader.ts
@@ -1,8 +1,13 @@
+export type Uniform<T = any> = {
+  value: T
+}
+
 export type Module = {
   vertexHeader: string
   vertexMain: string
   fragmentHeader: string
   fragmentMain: string
+  uniforms: Record<string, Uniform>
 }
 
 export const module = (input: Partial<Module>): Module => ({
@@ -10,6 +15,7 @@ export const module = (input: Partial<Module>): Module => ({
   vertexMain: "",
   fragmentHeader: "",
   fragmentMain: "",
+  uniforms: {},
   ...input
 })
 

--- a/packages/vfx/src/shaders/composableShader.ts
+++ b/packages/vfx/src/shaders/composableShader.ts
@@ -1,7 +1,4 @@
-export type GLSLType = "float" | "vec2" | "vec3" | "vec4" | "mat4" | "sampler2D"
-
 export type Uniform<T = any> = {
-  type: GLSLType
   value: T
 }
 

--- a/packages/vfx/src/shaders/composableShader.ts
+++ b/packages/vfx/src/shaders/composableShader.ts
@@ -32,6 +32,7 @@ export const composableShader = () => {
   function compileProgram(headers: string[], main: string[]) {
     return `
       ${headers.join("\n\n")}
+
       void main() {
         ${main.join("\n\n")}
       }

--- a/packages/vfx/src/shaders/composableShader.ts
+++ b/packages/vfx/src/shaders/composableShader.ts
@@ -1,4 +1,7 @@
+export type GLSLType = "float" | "vec2" | "vec3" | "vec4" | "mat4" | "sampler2D"
+
 export type Uniform<T = any> = {
+  type: GLSLType
   value: T
 }
 

--- a/packages/vfx/src/shaders/composableShader.ts
+++ b/packages/vfx/src/shaders/composableShader.ts
@@ -51,13 +51,7 @@ export const composableShader = () => {
         modules.map((m) => `{ ${m.fragmentMain} }`)
       ),
 
-      uniforms: {
-        u_time: { value: 0 },
-        u_depth: { value: null },
-        u_cameraNear: { value: 0 },
-        u_cameraFar: { value: 1 },
-        u_resolution: { value: [window.innerWidth, window.innerHeight] }
-      }
+      uniforms: modules.reduce((acc, m) => ({ ...acc, ...m.uniforms }), {})
     }
   }
 

--- a/packages/vfx/src/shaders/modules/softparticles.ts
+++ b/packages/vfx/src/shaders/modules/softparticles.ts
@@ -5,6 +5,13 @@ export default function(
   fun = "clamp(distance / softness, 0.0, 1.0)"
 ) {
   return module({
+    uniforms: {
+      u_depth: { value: null },
+      u_cameraNear: { value: 0 },
+      u_cameraFar: { value: 1 },
+      u_resolution: { value: [window.innerWidth, window.innerHeight] }
+    },
+
     vertexHeader: `
       varying float v_viewZ;
     `,

--- a/packages/vfx/src/shaders/modules/time.ts
+++ b/packages/vfx/src/shaders/modules/time.ts
@@ -3,7 +3,7 @@ import { module } from ".."
 export default function time(timeUniform = "u_time") {
   return module({
     uniforms: {
-      [timeUniform]: { type: "float", value: 0 }
+      [timeUniform]: { value: 0 }
     },
     vertexHeader: `uniform float ${timeUniform};`,
     fragmentHeader: `uniform float ${timeUniform};`

--- a/packages/vfx/src/shaders/modules/time.ts
+++ b/packages/vfx/src/shaders/modules/time.ts
@@ -3,7 +3,7 @@ import { module } from ".."
 export default function time(timeUniform = "u_time") {
   return module({
     uniforms: {
-      [timeUniform]: { value: 0 }
+      [timeUniform]: { type: "float", value: 0 }
     },
     vertexHeader: `uniform float ${timeUniform};`,
     fragmentHeader: `uniform float ${timeUniform};`

--- a/packages/vfx/src/shaders/modules/time.ts
+++ b/packages/vfx/src/shaders/modules/time.ts
@@ -1,8 +1,11 @@
 import { module } from ".."
 
-export default function time() {
+export default function time(timeUniform = "u_time") {
   return module({
-    vertexHeader: `uniform float u_time;`,
-    fragmentHeader: `uniform float u_time;`
+    uniforms: {
+      [timeUniform]: { value: 0 }
+    },
+    vertexHeader: `uniform float ${timeUniform};`,
+    fragmentHeader: `uniform float ${timeUniform};`
   })
 }


### PR DESCRIPTION
Shader modules can now register uniforms (which will eventually be passed into the material.) In this iteration, they still need to include the relevant shader header chunks. A future version will probably generate these automatically.

```tsx
export default function time(timeUniform = "u_time") {
  return module({
    uniforms: {
      [timeUniform]: { value: 0 }
    },
    vertexHeader: `uniform float ${timeUniform};`,
    fragmentHeader: `uniform float ${timeUniform};`
  })
}
```