### PR TITLE
Allow ShaderNodes as variable values

### DIFF
--- a/apps/examples/src/examples/Playground.tsx
+++ b/apps/examples/src/examples/Playground.tsx
@@ -42,20 +42,20 @@ function useShader() {
       diffuseColor: BlendNode({
         a: new Color("#dd8833"),
         b: MultiplyNode({
-          a: ColorNode({ color: new Color("#ffffff") }).value,
-          b: FresnelNode().value
-        }).value,
-        opacity: FloatNode({ value: 1 }).value
+          a: ColorNode({ color: new Color("#ffffff") }),
+          b: FresnelNode()
+        }),
+        opacity: 1
       }).value,
 
       position: AddNode({
-        a: VertexPositionNode().value,
+        a: VertexPositionNode(),
         b: WobbleNode({
-          x: TimeNode().value, // link to other nodes...
-          amplitude: 3, // ...or just use normal values!
+          x: TimeNode(),
+          amplitude: 3,
           frequency: 10
-        }).value
-      }).value
+        })
+      })
     })
 
     return compileShader(root)

--- a/apps/examples/src/examples/ShadenfreudeParticlesExample.tsx
+++ b/apps/examples/src/examples/ShadenfreudeParticlesExample.tsx
@@ -1,19 +1,12 @@
 import { useFrame } from "@react-three/fiber"
 import { useMemo } from "react"
 import {
-  AddNode,
   BlendNode,
   ColorNode,
   compileShader,
   CSMMasterNode,
-  float,
-  FloatNode,
   FresnelNode,
-  nodeFactory,
-  TimeNode,
-  Value,
-  vec3,
-  VertexPositionNode,
+  MixNode,
   MultiplyNode
 } from "shadenfreude"
 import { Color, MeshStandardMaterial } from "three"
@@ -23,7 +16,28 @@ type ModularShaderMaterialProps = Omit<iCSMProps, "ref">
 
 function useShader() {
   return useMemo(() => {
-    const root = CSMMasterNode({})
+    const baseColor = ColorNode({
+      color: new Color("#555")
+    }).value
+
+    const highlight = ColorNode({
+      color: new Color(2, 2, 2)
+    }).value
+
+    const fresnel = MultiplyNode({
+      a: highlight,
+      b: FresnelNode().value
+    }).value
+
+    const diffuseColor = BlendNode({
+      a: baseColor,
+      b: fresnel,
+      opacity: 1
+    }).value
+
+    const root = CSMMasterNode({
+      diffuseColor
+    })
 
     return compileShader(root)
   }, [])

--- a/apps/examples/src/examples/ShadenfreudeParticlesExample.tsx
+++ b/apps/examples/src/examples/ShadenfreudeParticlesExample.tsx
@@ -1,0 +1,53 @@
+import { useFrame } from "@react-three/fiber"
+import { useMemo } from "react"
+import {
+  AddNode,
+  BlendNode,
+  ColorNode,
+  compileShader,
+  CSMMasterNode,
+  float,
+  FloatNode,
+  FresnelNode,
+  nodeFactory,
+  TimeNode,
+  Value,
+  vec3,
+  VertexPositionNode,
+  MultiplyNode
+} from "shadenfreude"
+import { Color, MeshStandardMaterial } from "three"
+import CustomShaderMaterial, { iCSMProps } from "three-custom-shader-material"
+
+type ModularShaderMaterialProps = Omit<iCSMProps, "ref">
+
+function useShader() {
+  return useMemo(() => {
+    const root = CSMMasterNode({})
+
+    return compileShader(root)
+  }, [])
+}
+
+function MyMaterial({ children, ...props }: ModularShaderMaterialProps) {
+  const { update, ...shaderProps } = useShader()
+
+  // console.log(shaderProps.vertexShader)
+  console.log(shaderProps.fragmentShader)
+
+  useFrame(update)
+
+  return <CustomShaderMaterial {...props} {...shaderProps} />
+}
+
+export default function() {
+  return (
+    <group position-y={15}>
+      <mesh>
+        <sphereGeometry args={[8, 32, 32]} />
+
+        <MyMaterial baseMaterial={MeshStandardMaterial}></MyMaterial>
+      </mesh>
+    </group>
+  )
+}

--- a/apps/examples/src/examples/ShadenfreudeParticlesExample.tsx
+++ b/apps/examples/src/examples/ShadenfreudeParticlesExample.tsx
@@ -6,8 +6,7 @@ import {
   compileShader,
   CSMMasterNode,
   FresnelNode,
-  MixNode,
-  MultiplyNode
+  OperatorNode
 } from "shadenfreude"
 import { Color, MeshStandardMaterial } from "three"
 import CustomShaderMaterial, { iCSMProps } from "three-custom-shader-material"
@@ -17,23 +16,23 @@ type ModularShaderMaterialProps = Omit<iCSMProps, "ref">
 function useShader() {
   return useMemo(() => {
     const baseColor = ColorNode({
-      color: new Color("#555")
-    }).value
+      color: new Color("#800")
+    })
 
     const highlight = ColorNode({
       color: new Color(2, 2, 2)
-    }).value
+    })
 
-    const fresnel = MultiplyNode({
+    const fresnel = OperatorNode("*", {
       a: highlight,
-      b: FresnelNode().value
-    }).value
+      b: FresnelNode()
+    })
 
     const diffuseColor = BlendNode({
       a: baseColor,
       b: fresnel,
       opacity: 1
-    }).value
+    })
 
     const root = CSMMasterNode({
       diffuseColor

--- a/apps/examples/src/examples/ShadenfreudeParticlesExample.tsx
+++ b/apps/examples/src/examples/ShadenfreudeParticlesExample.tsx
@@ -23,7 +23,8 @@ function useShader() {
       color: new Color(2, 2, 2)
     })
 
-    const fresnel = OperatorNode("*", {
+    const fresnel = OperatorNode({
+      operator: "*",
       a: highlight,
       b: FresnelNode()
     })

--- a/apps/examples/src/examples/index.tsx
+++ b/apps/examples/src/examples/index.tsx
@@ -9,6 +9,7 @@ import { Simple } from "./Simple"
 import { Snow } from "./Snow"
 import { SoftParticlesExample } from "./SoftParticlesExample"
 import Playground from "./Playground"
+import ShadenfreudeParticlesExample from "./ShadenfreudeParticlesExample"
 
 export type ExampleDefinition = {
   path: string
@@ -45,5 +46,10 @@ export default [
     path: "playground",
     name: "Shadenfreude Playground",
     component: <Playground />
+  },
+  {
+    path: "shadenfreude-particles",
+    name: "Shadenfreude Particles",
+    component: <ShadenfreudeParticlesExample />
   }
 ] as ExampleDefinition[]

--- a/packages/shadenfreude/src/factories.ts
+++ b/packages/shadenfreude/src/factories.ts
@@ -25,6 +25,7 @@ export type ShaderNodeTemplate = Partial<ShaderNode>
 export function node(template: ShaderNodeTemplate) {
   /* Create node from template */
   const node: ShaderNode = {
+    _shaderNode: true,
     name: "Unnamed",
     uniforms: {},
     varyings: {},

--- a/packages/shadenfreude/src/nodes/math.ts
+++ b/packages/shadenfreude/src/nodes/math.ts
@@ -1,18 +1,22 @@
+import { Shader } from "three-vfx"
 import { node, variable, nodeFactory } from "../factories"
-import { Operator, Variable, Value } from "../types"
+import { Operator, Variable, Value, ShaderNode, isShaderNode } from "../types"
 
 export const OperatorNode = (
   operator: Operator,
-  inputs: { a: Variable; b: Variable }
-) =>
-  node({
-    name: `Perform ${operator} on ${inputs.a.type}`,
+  inputs: { a: Variable | ShaderNode; b: Variable | ShaderNode }
+) => {
+  const A = isShaderNode(inputs.a) ? inputs.a.value : inputs.a
+  const B = isShaderNode(inputs.b) ? inputs.b.value : inputs.b
+
+  return node({
+    name: `Perform ${operator} on ${A.type}`,
     inputs: {
-      a: variable(inputs.a.type, inputs.a),
-      b: variable(inputs.b.type, inputs.b)
+      a: variable(A.type, A),
+      b: variable(B.type, B)
     },
     outputs: {
-      value: variable(inputs.a.type)
+      value: variable(A.type)
     },
     vertex: {
       body: `value = a ${operator} b;`
@@ -21,14 +25,17 @@ export const OperatorNode = (
       body: `value = a ${operator} b;`
     }
   })
+}
 
-export const AddNode = nodeFactory<{ a: Variable; b: Variable }>(({ a, b }) =>
-  OperatorNode("+", { a, b })
-)
+export const AddNode = nodeFactory<{
+  a: Variable | ShaderNode
+  b: Variable | ShaderNode
+}>(({ a, b }) => OperatorNode("+", { a, b }))
 
-export const MultiplyNode = nodeFactory<{ a: Variable; b: Variable }>(
-  ({ a, b }) => OperatorNode("*", { a, b })
-)
+export const MultiplyNode = nodeFactory<{
+  a: Variable | ShaderNode
+  b: Variable | ShaderNode
+}>(({ a, b }) => OperatorNode("*", { a, b }))
 
 /* TODO: change this to accept Value args, not Variable! */
 export const MixNode = nodeFactory<{

--- a/packages/shadenfreude/src/nodes/math.ts
+++ b/packages/shadenfreude/src/nodes/math.ts
@@ -5,13 +5,9 @@ import {
   isShaderNode,
   isVariable,
   Operator,
-  ShaderNode,
   Value,
   Variable
 } from "../types"
-
-/* TODO: naming... oof */
-type VariableArgument = Variable | ShaderNode
 
 function lookupGLSLType(value: any): GLSLType {
   if (typeof value === "number") {
@@ -37,10 +33,6 @@ function wrapVariable(a: Value): Variable {
   } else {
     return variable(lookupGLSLType(a), a)
   }
-}
-
-function resolveVariableArgument(a: VariableArgument) {
-  return isShaderNode(a) ? a.value : a
 }
 
 export const OperatorNode = nodeFactory<{
@@ -81,19 +73,19 @@ export const MultiplyNode = nodeFactory<{
 
 /* TODO: change this to accept Value args, not Variable! */
 export const MixNode = nodeFactory<{
-  a: VariableArgument
-  b: VariableArgument
+  a: Value
+  b: Value
   factor: Value<"float">
 }>(({ a, b, factor }) => {
-  const A = resolveVariableArgument(a)
-  const B = resolveVariableArgument(b)
+  const A = wrapVariable(a)
+  const B = wrapVariable(b)
 
   return {
     name: "Mix",
     inputs: {
-      a: variable(A.type, A),
-      b: variable(B.type, B),
-      factor: variable("float", factor)
+      a: A,
+      b: B,
+      factor: wrapVariable(factor)
     },
     outputs: {
       value: variable(A.type)

--- a/packages/shadenfreude/src/nodes/math.ts
+++ b/packages/shadenfreude/src/nodes/math.ts
@@ -1,13 +1,20 @@
 import { node, nodeFactory, variable } from "../factories"
 import { isShaderNode, Operator, ShaderNode, Value, Variable } from "../types"
 
+/* TODO: naming... oof */
+type VariableArgument = Variable | ShaderNode
+
+function resolveVariableArgument(a: VariableArgument) {
+  return isShaderNode(a) ? a.value : a
+}
+
 export const OperatorNode = nodeFactory<{
   operator: Operator
-  a: Variable | ShaderNode
-  b: Variable | ShaderNode
+  a: VariableArgument
+  b: VariableArgument
 }>(({ a, b, operator }) => {
-  const A = isShaderNode(a) ? a.value : a
-  const B = isShaderNode(b) ? b.value : b
+  const A = resolveVariableArgument(a)
+  const B = resolveVariableArgument(b)
 
   return node({
     name: `Perform ${operator} on ${A.type}`,
@@ -28,13 +35,13 @@ export const OperatorNode = nodeFactory<{
 })
 
 export const AddNode = nodeFactory<{
-  a: Variable | ShaderNode
-  b: Variable | ShaderNode
+  a: VariableArgument
+  b: VariableArgument
 }>(({ a, b }) => OperatorNode({ operator: "+", a, b }))
 
 export const MultiplyNode = nodeFactory<{
-  a: Variable | ShaderNode
-  b: Variable | ShaderNode
+  a: VariableArgument
+  b: VariableArgument
 }>(({ a, b }) => OperatorNode({ operator: "*", a, b }))
 
 /* TODO: change this to accept Value args, not Variable! */

--- a/packages/shadenfreude/src/nodes/math.ts
+++ b/packages/shadenfreude/src/nodes/math.ts
@@ -1,12 +1,13 @@
 import { node, nodeFactory, variable } from "../factories"
 import { isShaderNode, Operator, ShaderNode, Value, Variable } from "../types"
 
-export const OperatorNode = (
-  operator: Operator,
-  inputs: { a: Variable | ShaderNode; b: Variable | ShaderNode }
-) => {
-  const A = isShaderNode(inputs.a) ? inputs.a.value : inputs.a
-  const B = isShaderNode(inputs.b) ? inputs.b.value : inputs.b
+export const OperatorNode = nodeFactory<{
+  operator: Operator
+  a: Variable | ShaderNode
+  b: Variable | ShaderNode
+}>(({ a, b, operator }) => {
+  const A = isShaderNode(a) ? a.value : a
+  const B = isShaderNode(b) ? b.value : b
 
   return node({
     name: `Perform ${operator} on ${A.type}`,
@@ -24,17 +25,17 @@ export const OperatorNode = (
       body: `value = a ${operator} b;`
     }
   })
-}
+})
 
 export const AddNode = nodeFactory<{
   a: Variable | ShaderNode
   b: Variable | ShaderNode
-}>(({ a, b }) => OperatorNode("+", { a, b }))
+}>(({ a, b }) => OperatorNode({ operator: "+", a, b }))
 
 export const MultiplyNode = nodeFactory<{
   a: Variable | ShaderNode
   b: Variable | ShaderNode
-}>(({ a, b }) => OperatorNode("*", { a, b }))
+}>(({ a, b }) => OperatorNode({ operator: "*", a, b }))
 
 /* TODO: change this to accept Value args, not Variable! */
 export const MixNode = nodeFactory<{

--- a/packages/shadenfreude/src/nodes/math.ts
+++ b/packages/shadenfreude/src/nodes/math.ts
@@ -46,23 +46,28 @@ export const MultiplyNode = nodeFactory<{
 
 /* TODO: change this to accept Value args, not Variable! */
 export const MixNode = nodeFactory<{
-  a: Variable
-  b: Variable
+  a: VariableArgument
+  b: VariableArgument
   factor: Value<"float">
-}>(({ a, b, factor }) => ({
-  name: "Mix",
-  inputs: {
-    a: variable(a.type, a),
-    b: variable(b.type, b),
-    factor: variable("float", factor)
-  },
-  outputs: {
-    value: variable(a.type)
-  },
-  vertex: {
-    body: `value = mix(a, b, factor);`
-  },
-  fragment: {
-    body: `value = mix(a, b, factor);`
+}>(({ a, b, factor }) => {
+  const A = resolveVariableArgument(a)
+  const B = resolveVariableArgument(b)
+
+  return {
+    name: "Mix",
+    inputs: {
+      a: variable(A.type, A),
+      b: variable(B.type, B),
+      factor: variable("float", factor)
+    },
+    outputs: {
+      value: variable(A.type)
+    },
+    vertex: {
+      body: `value = mix(a, b, factor);`
+    },
+    fragment: {
+      body: `value = mix(a, b, factor);`
+    }
   }
-}))
+})

--- a/packages/shadenfreude/src/nodes/math.ts
+++ b/packages/shadenfreude/src/nodes/math.ts
@@ -1,6 +1,5 @@
-import { Shader } from "three-vfx"
-import { node, variable, nodeFactory } from "../factories"
-import { Operator, Variable, Value, ShaderNode, isShaderNode } from "../types"
+import { node, nodeFactory, variable } from "../factories"
+import { isShaderNode, Operator, ShaderNode, Value, Variable } from "../types"
 
 export const OperatorNode = (
   operator: Operator,

--- a/packages/shadenfreude/src/nodes/math.ts
+++ b/packages/shadenfreude/src/nodes/math.ts
@@ -1,4 +1,4 @@
-import { Color, Vector2, Vector3, Vector4 } from "three"
+import { Color, Matrix3, Matrix4, Vector2, Vector3, Vector4 } from "three"
 import { node, nodeFactory, variable } from "../factories"
 import {
   GLSLType,
@@ -12,6 +12,8 @@ import {
 function lookupGLSLType(value: any): GLSLType {
   if (typeof value === "number") {
     return "float"
+  } else if (typeof value === "boolean") {
+    return "bool"
   } else if (value instanceof Color) {
     return "vec3"
   } else if (value instanceof Vector2) {
@@ -20,6 +22,10 @@ function lookupGLSLType(value: any): GLSLType {
     return "vec3"
   } else if (value instanceof Vector4) {
     return "vec4"
+  } else if (value instanceof Matrix3) {
+    return "mat3"
+  } else if (value instanceof Matrix4) {
+    return "mat4"
   } else {
     throw new Error(`Could not find a GLSL type for: ${value}`)
   }

--- a/packages/shadenfreude/src/types.ts
+++ b/packages/shadenfreude/src/types.ts
@@ -50,6 +50,7 @@ export type Variable<T extends GLSLType = any> = {
 export type Value<T extends GLSLType = any> =
   | GLSLtoJSType<T>
   | Variable<T>
+  | ShaderNode<T>
   | string
 
 export type Variables = Record<string, Variable>
@@ -60,6 +61,8 @@ export type Program = {
 }
 
 export type ShaderNode<T extends GLSLType = any> = {
+  _shaderNode: true
+
   name: string
 
   /* Header Variables */
@@ -81,4 +84,8 @@ export type ShaderNode<T extends GLSLType = any> = {
 
 export function isVariable(value: any): value is Variable {
   return !!value?._variable
+}
+
+export function isShaderNode(value: any): value is ShaderNode {
+  return !!value?._shaderNode
 }


### PR DESCRIPTION
The change in this PR allows you to set an actual `ShaderNode` as a variable value, enabling code to look like this:

```ts
const root = CSMMasterNode({
  diffuseColor: BlendNode({
    a: new Color("#dd8833"),
    b: MultiplyNode({
      a: ColorNode({ color: new Color("#ffffff") }),
      b: FresnelNode()
    }),
    opacity: 1
  }).value,

  position: AddNode({
    a: VertexPositionNode(),
    b: WobbleNode({
      x: TimeNode(),
      amplitude: 3,
      frequency: 10
    })
  })
})
```