### PR TITLE
UniformNode

### DIFF
--- a/apps/examples/src/examples/Playground.tsx
+++ b/apps/examples/src/examples/Playground.tsx
@@ -38,12 +38,6 @@ const WobbleNode = nodeFactory<{
 
 function useShader() {
   return useMemo(() => {
-    const timeUniform = UniformNode({
-      name: "u_time",
-      type: "float",
-      initialValue: 0
-    })
-
     const root = CSMMasterNode({
       diffuseColor: BlendNode({
         a: new Color("#dd8833"),
@@ -57,9 +51,7 @@ function useShader() {
       position: AddNode({
         a: VertexPositionNode(),
         b: WobbleNode({
-          x: TimeNode({
-            source: timeUniform
-          }),
+          x: TimeNode(),
           amplitude: 3,
           frequency: 10
         })
@@ -77,9 +69,7 @@ function MyMaterial({ children, ...props }: ModularShaderMaterialProps) {
   // console.log(shaderProps.vertexShader)
   console.log(shaderProps.fragmentShader)
 
-  useFrame((_, dt) => {
-    material.current.uniforms.u_time.value += dt
-  })
+  useFrame(update)
 
   return <CustomShaderMaterial {...props} {...shaderProps} ref={material} />
 }

--- a/packages/shadenfreude/src/compilers.ts
+++ b/packages/shadenfreude/src/compilers.ts
@@ -178,8 +178,7 @@ export function compileShader(root: ShaderNode) {
     /* Determine a unique name for the node */
     const prefix = `node_${nextId()}_${node.prefix || tableize(node.name)}`
 
-    /* Give node-specific global names to uniforms, varyings, inputs, and outputs. */
-    tweakVariableNames(node.uniforms, prefix, "uniform")
+    /* Give node-specific global names to varyings, inputs, and outputs. */
     tweakVariableNames(node.varyings, prefix, "varying")
     tweakVariableNames(node.inputs, prefix, "input")
     tweakVariableNames(node.outputs, prefix, "output")

--- a/packages/shadenfreude/src/nodes/inputs/TimeNode.ts
+++ b/packages/shadenfreude/src/nodes/inputs/TimeNode.ts
@@ -1,16 +1,19 @@
 import { node, nodeFactory } from "../../factories"
+import { Value } from "../../types"
 import { float } from "../../variables"
 
-export const TimeNode = nodeFactory(() => {
-  const u_time = float(0)
-
-  return node({
-    name: "Time Uniform",
-    uniforms: { u_time },
-    outputs: { value: float(u_time) },
-
-    update: (_, dt) => {
-      ;(u_time.value as number)! += dt
-    }
-  })
-})
+export const TimeNode = nodeFactory<{ source: Value<"float"> }>(
+  ({ source }) => {
+    return node({
+      name: "Time Uniform",
+      inputs: {
+        time: float(source)
+      },
+      outputs: {
+        value: float("time"),
+        sinTime: float("sin(time)"),
+        cosTime: float("sin(time)")
+      }
+    })
+  }
+)

--- a/packages/shadenfreude/src/nodes/inputs/TimeNode.ts
+++ b/packages/shadenfreude/src/nodes/inputs/TimeNode.ts
@@ -1,4 +1,5 @@
-import { nodeFactory, node, float } from "../.."
+import { node, nodeFactory } from "../../factories"
+import { float } from "../../variables"
 
 export const TimeNode = nodeFactory(() => {
   const u_time = float(0)

--- a/packages/shadenfreude/src/nodes/inputs/TimeNode.ts
+++ b/packages/shadenfreude/src/nodes/inputs/TimeNode.ts
@@ -1,13 +1,25 @@
 import { node, nodeFactory } from "../../factories"
-import { Value } from "../../types"
+import { ShaderNode } from "../../types"
 import { float } from "../../variables"
+import { UniformNode } from "./UniformNode"
 
-export const TimeNode = nodeFactory<{ source: Value<"float"> }>(
-  ({ source }) => {
+export const TimeNode = nodeFactory<{ uniformName: string }>(
+  ({ uniformName = "u_time" }) => {
+    /* TODO: insert memoization here */
+    const uniform: ShaderNode = UniformNode({
+      name: uniformName,
+      type: "float",
+      initialValue: 0
+    })
+
+    uniform.update = (_, dt) => {
+      ;(uniform.uniforms[uniformName].value as number) += dt
+    }
+
     return node({
-      name: "Time Uniform",
+      name: "Time",
       inputs: {
-        time: float(source)
+        time: float(uniform)
       },
       outputs: {
         value: float("time"),

--- a/packages/shadenfreude/src/nodes/inputs/UniformNode.ts
+++ b/packages/shadenfreude/src/nodes/inputs/UniformNode.ts
@@ -1,0 +1,17 @@
+import { nodeFactory } from "../../factories"
+import { GLSLType } from "../../types"
+import { variable } from "../../variables"
+
+export const UniformNode = nodeFactory<{ type: GLSLType; name: string }>(
+  ({ type, name }) => ({
+    outputs: {
+      value: variable(type, name)
+    },
+    vertex: {
+      header: `uniform ${type} ${name};`
+    },
+    fragment: {
+      header: `uniform ${type} ${name};`
+    }
+  })
+)

--- a/packages/shadenfreude/src/nodes/inputs/UniformNode.ts
+++ b/packages/shadenfreude/src/nodes/inputs/UniformNode.ts
@@ -1,17 +1,16 @@
 import { nodeFactory } from "../../factories"
-import { GLSLType } from "../../types"
+import { GLSLType, Value } from "../../types"
 import { variable } from "../../variables"
 
-export const UniformNode = nodeFactory<{ type: GLSLType; name: string }>(
-  ({ type, name }) => ({
-    outputs: {
-      value: variable(type, name)
-    },
-    vertex: {
-      header: `uniform ${type} ${name};`
-    },
-    fragment: {
-      header: `uniform ${type} ${name};`
-    }
-  })
-)
+export const UniformNode = nodeFactory<{
+  type: GLSLType
+  name: string
+  initialValue: Value
+}>(({ type, name, initialValue }) => ({
+  uniforms: {
+    [name]: { ...variable(type, initialValue), name }
+  },
+  outputs: {
+    value: variable(type, name)
+  }
+}))

--- a/packages/shadenfreude/src/nodes/inputs/index.ts
+++ b/packages/shadenfreude/src/nodes/inputs/index.ts
@@ -1,3 +1,4 @@
 export * from "./AttributeNode"
 export * from "./TimeNode"
+export * from "./UniformNode"
 export * from "./VertexPositionNode"


### PR DESCRIPTION
- Adds a `UniformNode` that lets you declare a uniform
- Changes `TimeNode` to use a `UniformNode`

Todo:

- [x] Implement a new `UniformNode`
- [x] Change `TimeNode` to use it (instead of defining its own uniform)
- [x] Find a good new way to house the per-frame update concern