### PR TITLE
Remove `value` accessor

### DIFF
--- a/packages/shadenfreude/src/compilers.ts
+++ b/packages/shadenfreude/src/compilers.ts
@@ -18,7 +18,7 @@ type Program = "vertex" | "fragment"
 
 export function resolveValue(v: Value): Value | undefined {
   if (isShaderNode(v)) {
-    return v.value
+    return v.outputs.value
   } else {
     return v
   }
@@ -47,7 +47,7 @@ function nodeTitle(node: ShaderNode) {
 function dependencies(node: ShaderNode, deps = new Array<ShaderNode>()) {
   for (const variable of Object.values(node.inputs)) {
     const dependencyVariable = isShaderNode(variable.value)
-      ? variable.value.value
+      ? variable.value.outputs.value
       : variable.value
 
     if (isVariable(dependencyVariable)) {

--- a/packages/shadenfreude/src/factories.ts
+++ b/packages/shadenfreude/src/factories.ts
@@ -14,11 +14,7 @@ export function node(template: ShaderNodeTemplate) {
     outputs: {},
     vertex: { header: "", body: "" },
     fragment: { header: "", body: "" },
-    ...template,
-
-    get value() {
-      return this.outputs.value
-    }
+    ...template
   }
 
   /* Register outputs */

--- a/packages/shadenfreude/src/helpers.ts
+++ b/packages/shadenfreude/src/helpers.ts
@@ -5,7 +5,7 @@ export function glslType(value: Value): GLSLType {
   if (isVariable(value)) {
     return value.type
   } else if (isShaderNode(value)) {
-    return glslType(value.value)
+    return glslType(value.outputs.value)
   } else if (typeof value === "number") {
     return "float"
   } else if (typeof value === "boolean") {

--- a/packages/shadenfreude/src/types.ts
+++ b/packages/shadenfreude/src/types.ts
@@ -80,7 +80,6 @@ export type ShaderNode<T extends GLSLType = any> = {
   /* Variables */
   inputs: Variables
   outputs: Variables
-  value: Variable<T>
 
   /* etc. */
   update?: RenderCallback

--- a/packages/shadenfreude/src/variables.ts
+++ b/packages/shadenfreude/src/variables.ts
@@ -46,7 +46,7 @@ export function inferVariable(a: Value): Variable {
   if (isVariable(a)) {
     return variable(a.type, a)
   } else if (isShaderNode(a)) {
-    return inferVariable(a.value)
+    return inferVariable(a.outputs.value)
   } else {
     return variable(glslType(a), a)
   }


### PR DESCRIPTION
It is no longer needed, because you can now directly assign ShaderNodes to variable values.