### PR TITLE
`a` as default input

### DIFF
--- a/apps/examples/src/examples/StacksExample.tsx
+++ b/apps/examples/src/examples/StacksExample.tsx
@@ -38,12 +38,12 @@ const AnimationStack = Factory(() => ({
 const ScaleWithTime = Factory<{ axis?: string }>(({ axis = "xyz" }) => ({
   name: "Scale with Time",
   in: {
-    value: vec3(),
+    a: vec3(),
     frequency: float(1),
     time: float(TimeNode())
   },
   out: {
-    value: vec3("in_value")
+    value: vec3("in_a")
   },
   vertex: {
     body: `out_value.${axis} *= (1.0 + sin(in_time * in_frequency) * 0.5);`
@@ -53,13 +53,13 @@ const ScaleWithTime = Factory<{ axis?: string }>(({ axis = "xyz" }) => ({
 const SqueezeWithTime = Factory<{ axis?: string }>(() => ({
   name: "Squeeze with Time",
   in: {
-    value: vec3(),
+    a: vec3(),
 
     frequency: float(1),
     time: float(TimeNode())
   },
   out: {
-    value: vec3("in_value")
+    value: vec3("in_a")
   },
   vertex: {
     body: `out_value.x *= (1.0 + sin(in_time * in_frequency + position.y * 0.3 + position.x * 0.3) * 0.2);`
@@ -69,13 +69,13 @@ const SqueezeWithTime = Factory<{ axis?: string }>(() => ({
 const MoveWithTime = Factory<{ axis?: string }>(({ axis = "xyz" }) => ({
   name: "Move with Time",
   in: {
-    value: vec3(),
+    a: vec3(),
     frequency: float(1),
     amplitude: float(1),
     time: float(TimeNode())
   },
   out: {
-    value: vec3("in_value")
+    value: vec3("in_a")
   },
   vertex: {
     body: `out_value.${axis} += sin(in_time * in_frequency) * in_amplitude;`
@@ -85,12 +85,12 @@ const MoveWithTime = Factory<{ axis?: string }>(({ axis = "xyz" }) => ({
 const FauxLamina = Factory(() => ({
   name: "Faux Lamina",
   in: {
-    value: vec3(),
+    a: vec3(),
     color: vec3(),
     intensity: float(0.5)
   },
   out: {
-    value: vec3("in_color * in_intensity + in_value * (1.0 - in_intensity)")
+    value: vec3("in_color * in_intensity + in_a * (1.0 - in_intensity)")
   }
 }))
 

--- a/packages/shadenfreude/src/shadenfreude.ts
+++ b/packages/shadenfreude/src/shadenfreude.ts
@@ -451,10 +451,10 @@ export const compileShader = (root: IShaderNode) => {
       const firstFilter = node.filters[0]
 
       if (!isShaderNodeWithInVariable(firstFilter))
-        throw new Error("Filter nodes must have an input value")
+        throw new Error("Filter nodes must have an `a` input")
 
       if (!isShaderNodeWithOutVariable(lastFilter))
-        throw new Error("Filter nodes must have an output value")
+        throw new Error("Filter nodes must have a `value` output")
 
       firstFilter.in.a = node.out.value
 
@@ -464,10 +464,10 @@ export const compileShader = (root: IShaderNode) => {
         const prev = node.filters[i - 1]
 
         if (!isShaderNodeWithOutVariable(prev))
-          throw new Error("Filter nodes must have an output value")
+          throw new Error("Filter nodes must have a `value` output")
 
         if (!isShaderNodeWithInVariable(filter))
-          throw new Error("Filter nodes must have an input value")
+          throw new Error("Filter nodes must have an `a` input")
 
         filter.in.a.value = prev.out.value
       }

--- a/packages/shadenfreude/src/shadenfreude.ts
+++ b/packages/shadenfreude/src/shadenfreude.ts
@@ -37,7 +37,7 @@ export interface IShaderNode {
 
 export interface IShaderNodeWithInVariable<T extends ValueType = any> {
   [key: string]: any
-  in: { value: Variable<T> }
+  in: { a: Variable<T> }
 }
 
 export interface IShaderNodeWithOutVariable<T extends ValueType = any> {
@@ -456,7 +456,7 @@ export const compileShader = (root: IShaderNode) => {
       if (!isShaderNodeWithOutVariable(lastFilter))
         throw new Error("Filter nodes must have an output value")
 
-      firstFilter.in.value = node.out.value
+      firstFilter.in.a = node.out.value
 
       /* Connect filters in sequence */
       for (let i = 1; i < node.filters.length; i++) {
@@ -469,7 +469,7 @@ export const compileShader = (root: IShaderNode) => {
         if (!isShaderNodeWithInVariable(filter))
           throw new Error("Filter nodes must have an input value")
 
-        filter.in.value.value = prev.out.value
+        filter.in.a.value = prev.out.value
       }
     }
 
@@ -524,7 +524,7 @@ export const isVariable = (value: any): value is Variable => !!value?.__variable
 
 export const isShaderNodeWithInVariable = (
   value: any
-): value is IShaderNodeWithInVariable => value?.in?.value !== undefined
+): value is IShaderNodeWithInVariable => value?.in?.a !== undefined
 
 export const isShaderNodeWithOutVariable = (
   value: any

--- a/packages/shadenfreude/test/shadenfreude.test.ts
+++ b/packages/shadenfreude/test/shadenfreude.test.ts
@@ -423,8 +423,8 @@ describe("compileShader", () => {
     const AdditionFilter = Factory(() => ({
       name: "Addition",
       in: {
-        value: float(),
-        other: float()
+        a: float(),
+        b: float()
       },
       out: {
         value: float(`in_value + in_other`)
@@ -434,12 +434,12 @@ describe("compileShader", () => {
     const nodeWithfilters = ShaderNode({
       name: "Node with filters",
       in: {
-        value: float(1)
+        a: float(1)
       },
       out: {
         value: float("in_value")
       },
-      filters: [AdditionFilter({ other: 2 })]
+      filters: [AdditionFilter({ b: 2 })]
     })
 
     const [c] = compileShader(nodeWithfilters)
@@ -459,14 +459,14 @@ describe("compileShader", () => {
         /*** BEGIN: Node with filters ***/
         float out_Node_with_filters_1_value;
         {
-          float in_value = 1.0;
+          float in_a = 1.0;
           float out_value = in_value;
           out_Node_with_filters_1_value = out_value;
           /*** BEGIN: Addition ***/
           float out_Addition_2_value;
           {
-            float in_value = in_value;
-            float in_other = 2.0;
+            float in_a = in_value;
+            float in_b = 2.0;
             float out_value = in_value + in_other;
             out_Addition_2_value = out_value;
           }


### PR DESCRIPTION
This changes the convention regarding default input variables from `node.in.value` to `node.in.a`.