### PR TITLE
Move internal variable configuration into _config

### DIFF
--- a/packages/shadenfreude/src/compilers.test.ts
+++ b/packages/shadenfreude/src/compilers.test.ts
@@ -20,10 +20,13 @@ describe("compileShader", () => {
   it("includes the variable's chunks if it has them", () => {
     const v = Variable("float", 1)
 
-    v.vertexHeader = statement("uniform float u_time")
-    v.vertexBody = assignment("gl_Position", "vec4(sin(u_time), 0.0, 0.0, 1.0)")
-    v.fragmentHeader = statement("uniform float u_time")
-    v.fragmentBody = assignment(
+    v._config.vertexHeader = statement("uniform float u_time")
+    v._config.vertexBody = assignment(
+      "gl_Position",
+      "vec4(sin(u_time), 0.0, 0.0, 1.0)"
+    )
+    v._config.fragmentHeader = statement("uniform float u_time")
+    v._config.fragmentBody = assignment(
       "gl_FragColor",
       "vec4(cos(u_time), 0.0, 0.0, 1.0)"
     )

--- a/packages/shadenfreude/src/glslRepresentation.ts
+++ b/packages/shadenfreude/src/glslRepresentation.ts
@@ -2,7 +2,7 @@ import { Color, Vector2, Vector3, Vector4 } from "three"
 import { isVariable, Value } from "./variables"
 
 export const glslRepresentation = (value: Value): string => {
-  if (isVariable(value)) return value.name
+  if (isVariable(value)) return value._config.name
 
   if (typeof value === "string") return value
 

--- a/packages/shadenfreude/src/nodes/vectors.test.ts
+++ b/packages/shadenfreude/src/nodes/vectors.test.ts
@@ -5,25 +5,25 @@ describe("Join", () => {
   it("creates a vec2 variable from two components", () => {
     const v = Join(1, 2)
     expect(v.type).toBe("vec2")
-    expect(v.inputs.x).toBe(1)
-    expect(v.inputs.y).toBe(2)
+    expect(v._config.inputs.x).toBe(1)
+    expect(v._config.inputs.y).toBe(2)
   })
 
   it("creates a vec3 variable from three components", () => {
     const v = Join(1, 2, 3)
     expect(v.type).toBe("vec3")
-    expect(v.inputs.x).toBe(1)
-    expect(v.inputs.y).toBe(2)
-    expect(v.inputs.z).toBe(3)
+    expect(v._config.inputs.x).toBe(1)
+    expect(v._config.inputs.y).toBe(2)
+    expect(v._config.inputs.z).toBe(3)
   })
 
   it("creates a vec4 variable from three components", () => {
     const v = Join(1, 2, 3, 4)
     expect(v.type).toBe("vec4")
-    expect(v.inputs.x).toBe(1)
-    expect(v.inputs.y).toBe(2)
-    expect(v.inputs.z).toBe(3)
-    expect(v.inputs.w).toBe(4)
+    expect(v._config.inputs.x).toBe(1)
+    expect(v._config.inputs.y).toBe(2)
+    expect(v._config.inputs.z).toBe(3)
+    expect(v._config.inputs.w).toBe(4)
   })
 })
 

--- a/packages/shadenfreude/src/variables.test.ts
+++ b/packages/shadenfreude/src/variables.test.ts
@@ -21,7 +21,7 @@ describe("variable", () => {
     const source = Float(1)
     const v = Float(source)
     expect(v.value).toBe(source)
-    expect(glsl(v.value)).toBe(source.name)
+    expect(glsl(v.value)).toBe(source._config.name)
   })
 
   it("supports a 'varying' flag that will automatically make it pass its data as a varying", () => {

--- a/packages/shadenfreude/src/variables.ts
+++ b/packages/shadenfreude/src/variables.ts
@@ -27,8 +27,7 @@ export type Value<T extends GLSLType = any> = string | JSTypes[T] | Variable<T>
 
 export type Chunk = Part | Part[]
 
-export type Variable<T extends GLSLType = any> = {
-  _: "Variable"
+export type VariableState<T extends GLSLType = any> = {
   id: number
   title: string
   name: string
@@ -41,6 +40,10 @@ export type Variable<T extends GLSLType = any> = {
   vertexBody?: Chunk
   fragmentHeader?: Chunk
   fragmentBody?: Chunk
+}
+
+export type Variable<T extends GLSLType = any> = VariableState<T> & {
+  _: "Variable"
 }
 
 const nextAnonymousId = idGenerator()

--- a/packages/shadenfreude/src/variables.ts
+++ b/packages/shadenfreude/src/variables.ts
@@ -51,11 +51,11 @@ const nextAnonymousId = idGenerator()
 export const Variable = <T extends GLSLType>(
   type: T,
   value: Value<T>,
-  config: Partial<VariableConfig<T>> = {}
+  configInput: Partial<VariableConfig<T>> = {}
 ) => {
   const id = nextAnonymousId()
 
-  const state: VariableConfig<T> = {
+  const config: VariableConfig<T> = {
     /* Defaults */
     id,
     title: `Anonymous ${type} = ${glslRepresentation(value)}`,
@@ -63,7 +63,7 @@ export const Variable = <T extends GLSLType>(
     inputs: {},
 
     /* User-provided configuration */
-    ...config,
+    ...configInput,
 
     /* Override with provided type and value */
     type,
@@ -72,7 +72,7 @@ export const Variable = <T extends GLSLType>(
 
   const v: Variable<T> = {
     _: "Variable",
-    ...state
+    ...config
   }
 
   return v

--- a/packages/shadenfreude/src/variables.ts
+++ b/packages/shadenfreude/src/variables.ts
@@ -51,19 +51,28 @@ const nextAnonymousId = idGenerator()
 export const Variable = <T extends GLSLType>(
   type: T,
   value: Value<T>,
-  extras: Partial<Variable<T>> = {}
+  config: Partial<VariableState<T>> = {}
 ) => {
   const id = nextAnonymousId()
 
-  const v: Variable<T> = {
+  const state: VariableState<T> = {
+    /* Defaults */
     id,
     title: `Anonymous ${type} = ${glslRepresentation(value)}`,
     name: identifier("anonymous", id),
     inputs: {},
-    ...extras,
-    _: "Variable",
+
+    /* User-provided configuration */
+    ...config,
+
+    /* Override with provided type and value */
     type,
     value
+  }
+
+  const v: Variable<T> = {
+    _: "Variable",
+    ...state
   }
 
   return v

--- a/packages/shadenfreude/src/variables.ts
+++ b/packages/shadenfreude/src/variables.ts
@@ -40,8 +40,9 @@ export type VariableConfig<T extends GLSLType = any> = {
   fragmentBody?: Chunk
 }
 
-export type Variable<T extends GLSLType = any> = VariableConfig<T> & {
+export type Variable<T extends GLSLType = any> = {
   _: "Variable"
+  _config: VariableConfig<T>
   type: T
   value: Value<T>
 }
@@ -68,7 +69,7 @@ export const Variable = <T extends GLSLType>(
 
   const v: Variable<T> = {
     _: "Variable",
-    ...config,
+    _config: config,
     type,
     value
   }
@@ -88,7 +89,7 @@ export function isType<T extends GLSLType>(v: any, t: T): v is Value<T> {
 
 const makeVariableHelper = <T extends GLSLType>(type: T) => (
   v: Value<T>,
-  extras?: Partial<Variable<T>>
+  extras?: Partial<VariableConfig<T>>
 ) => Variable(type, v, extras)
 
 export const Float = makeVariableHelper("float")

--- a/packages/shadenfreude/src/variables.ts
+++ b/packages/shadenfreude/src/variables.ts
@@ -27,7 +27,7 @@ export type Value<T extends GLSLType = any> = string | JSTypes[T] | Variable<T>
 
 export type Chunk = Part | Part[]
 
-export type VariableState<T extends GLSLType = any> = {
+export type VariableConfig<T extends GLSLType = any> = {
   id: number
   title: string
   name: string
@@ -42,7 +42,7 @@ export type VariableState<T extends GLSLType = any> = {
   fragmentBody?: Chunk
 }
 
-export type Variable<T extends GLSLType = any> = VariableState<T> & {
+export type Variable<T extends GLSLType = any> = VariableConfig<T> & {
   _: "Variable"
 }
 
@@ -51,11 +51,11 @@ const nextAnonymousId = idGenerator()
 export const Variable = <T extends GLSLType>(
   type: T,
   value: Value<T>,
-  config: Partial<VariableState<T>> = {}
+  config: Partial<VariableConfig<T>> = {}
 ) => {
   const id = nextAnonymousId()
 
-  const state: VariableState<T> = {
+  const state: VariableConfig<T> = {
     /* Defaults */
     id,
     title: `Anonymous ${type} = ${glslRepresentation(value)}`,

--- a/packages/shadenfreude/src/variables.ts
+++ b/packages/shadenfreude/src/variables.ts
@@ -31,8 +31,6 @@ export type VariableConfig<T extends GLSLType = any> = {
   id: number
   title: string
   name: string
-  type: T
-  value: Value<T>
   inputs: Record<string, Value>
   only?: "vertex" | "fragment"
   varying?: boolean
@@ -44,6 +42,8 @@ export type VariableConfig<T extends GLSLType = any> = {
 
 export type Variable<T extends GLSLType = any> = VariableConfig<T> & {
   _: "Variable"
+  type: T
+  value: Value<T>
 }
 
 const nextAnonymousId = idGenerator()
@@ -63,16 +63,14 @@ export const Variable = <T extends GLSLType>(
     inputs: {},
 
     /* User-provided configuration */
-    ...configInput,
-
-    /* Override with provided type and value */
-    type,
-    value
+    ...configInput
   }
 
   const v: Variable<T> = {
     _: "Variable",
-    ...config
+    ...config,
+    type,
+    value
   }
 
   return v


### PR DESCRIPTION
A bit of cleanup to separate the internal variable configuration from its external API (mostly in preparation for allowing variables to provide their own accessors.)