### PR TITLE
Variables as interface

### DIFF
--- a/packages/shadenfreude/src/variables.ts
+++ b/packages/shadenfreude/src/variables.ts
@@ -40,7 +40,7 @@ export type VariableConfig<T extends GLSLType = any> = {
   fragmentBody?: Chunk
 }
 
-export type Variable<T extends GLSLType = any> = {
+export interface Variable<T extends GLSLType = any> {
   _: "Variable"
   _config: VariableConfig<T>
   type: T

--- a/packages/shadenfreude/src/variables.ts
+++ b/packages/shadenfreude/src/variables.ts
@@ -40,12 +40,14 @@ export type VariableConfig<T extends GLSLType = any> = {
   fragmentBody?: Chunk
 }
 
-export interface Variable<T extends GLSLType = any> {
+export interface IVariable<T extends GLSLType = any> {
   _: "Variable"
   _config: VariableConfig<T>
   type: T
   value: Value<T>
 }
+
+export type Variable<T extends GLSLType = any> = IVariable<T>
 
 const nextAnonymousId = idGenerator()
 

--- a/packages/shadenfreude/src/variables.ts
+++ b/packages/shadenfreude/src/variables.ts
@@ -40,6 +40,10 @@ export type VariableConfig<T extends GLSLType = any> = {
   fragmentBody?: Chunk
 }
 
+/**
+ * Any object that extends the IVariable type can be a variable in the shader tree.
+ * Variable objects are free to expose any additional properties on top of this.
+ */
 export interface IVariable<T extends GLSLType = any> {
   _: "Variable"
   _config: VariableConfig<T>
@@ -47,7 +51,10 @@ export interface IVariable<T extends GLSLType = any> {
   value: Value<T>
 }
 
-export type Variable<T extends GLSLType = any> = IVariable<T>
+export type Variable<
+  T extends GLSLType = any,
+  API extends Record<string, any> = {}
+> = IVariable<T> & API
 
 const nextAnonymousId = idGenerator()
 


### PR DESCRIPTION
This moves most of `Variable` into an `IVariable` interface, and simply extends this for the `Variable` type. Also in preparation for future API support.