### PR TITLE
Tagged template expressions!

### DIFF
--- a/apps/examples/src/examples/Playground.tsx
+++ b/apps/examples/src/examples/Playground.tsx
@@ -2,7 +2,7 @@ import {
   Add,
   CustomShaderMaterialMaster,
   Dissolve,
-  expr,
+  code,
   Float,
   Mix,
   Mul,
@@ -36,7 +36,7 @@ export default function Playground() {
     const steppedNoise = Smoothstep(-0, 1, noise)
 
     const waterHeight = Float(
-      expr`0.3 + sin(${Time} + ${VertexPosition}.y) * 0.02`
+      code`0.3 + sin(${Time} + ${VertexPosition}.y) * 0.02`
     )
 
     const waterNoise = Step(
@@ -47,7 +47,7 @@ export default function Playground() {
     const dissolve = Dissolve(Smoothstep(-0.5, 0.5, Sin(Time)), 0.1)
 
     return CustomShaderMaterialMaster({
-      position: Mul(VertexPosition, Float(expr`1.0 + ${steppedNoise} * 0.3`)),
+      position: Mul(VertexPosition, Float(code`1.0 + ${steppedNoise} * 0.3`)),
 
       diffuseColor: Pipe(
         Vec3(new Color("#66c")),

--- a/apps/examples/src/examples/Playground.tsx
+++ b/apps/examples/src/examples/Playground.tsx
@@ -1,5 +1,5 @@
-import { expr, Float, snippet } from "shadenfreude"
-import { DoubleSide, MeshStandardMaterial } from "three"
+import { expr, Float, snippet, Vec3 } from "shadenfreude"
+import { Color, DoubleSide, MeshStandardMaterial } from "three"
 import CustomShaderMaterial from "three-custom-shader-material"
 import { useShader } from "./useShader"
 
@@ -12,9 +12,13 @@ export default function Playground() {
     const a = Float(1)
     const b = Float(2)
 
+    const c = Vec3(new Color("hotpink"))
+
     // return Float(expr`${add}(${a}, ${b})`)
 
-    return Float(expr`${a} + ${b}`)
+    return Float(expr`${a} + ${b}`, {
+      fragmentBody: `csm_DiffuseColor = vec4(1.0, 0.5, 0.2, 1.0);`
+    })
 
     // const noise = Simplex3DNoise(VertexPosition)
 
@@ -24,8 +28,8 @@ export default function Playground() {
     // })
   }, [])
 
-  console.log(shader.vertexShader)
-  // console.log(shader.fragmentShader)
+  // console.log(shader.vertexShader)
+  console.log(shader.fragmentShader)
 
   return (
     <group position-y={15}>

--- a/apps/examples/src/examples/Playground.tsx
+++ b/apps/examples/src/examples/Playground.tsx
@@ -4,6 +4,7 @@ import {
   expr,
   Float,
   Mix,
+  Mul,
   Multiply,
   Pipe,
   Pow,
@@ -11,6 +12,8 @@ import {
   Simplex3DNoise,
   Smoothstep,
   Step,
+  Sub,
+  Subtract,
   Time,
   Vec3,
   VertexPosition
@@ -23,7 +26,7 @@ import { useShader } from "./useShader"
 export default function Playground() {
   const shader = useShader(() => {
     const noise = Pow(
-      Remap(Simplex3DNoise(Vec3(Multiply(VertexPosition, 0.11))), -1, 1, 0, 1),
+      Remap(Simplex3DNoise(Vec3(Mul(VertexPosition, 0.11))), -1, 1, 0, 1),
       1.5
     )
 
@@ -34,15 +37,12 @@ export default function Playground() {
     )
 
     return CustomShaderMaterialMaster({
-      position: Multiply(
-        VertexPosition,
-        Float(expr`1.0 + ${steppedNoise} * 0.3`)
-      ),
+      position: Mul(VertexPosition, Float(expr`1.0 + ${steppedNoise} * 0.3`)),
 
       diffuseColor: Pipe(
         Vec3(new Color("#66c")),
-        ($) => Mix($, new Color("#68f"), Step(waterHeight, noise)),
-        ($) => Mix($, new Color("#ec5"), Step(Add(waterHeight, 0.02), noise)),
+        ($) => Mix($, new Color("#68f"), Step(Sub(waterHeight, 0.02), noise)),
+        ($) => Mix($, new Color("#ec5"), Step(waterHeight, noise)),
         ($) => Mix($, new Color("#494"), Step(0.34, noise)),
         ($) => Mix($, new Color("#ccc"), Step(0.5, noise)),
         ($) => Mix($, new Color("#fff"), Step(0.7, noise))

--- a/apps/examples/src/examples/Playground.tsx
+++ b/apps/examples/src/examples/Playground.tsx
@@ -1,11 +1,7 @@
 import {
   CustomShaderMaterialMaster,
-  expr,
-  Float,
   Simplex3DNoise,
   Smoothstep,
-  snippet,
-  Vec3,
   VertexPosition
 } from "shadenfreude"
 import { Color, DoubleSide, MeshStandardMaterial } from "three"
@@ -14,20 +10,6 @@ import { useShader } from "./useShader"
 
 export default function Playground() {
   const shader = useShader(() => {
-    const mul = snippet(
-      (name) => `float ${name}(float a, float b) { return a * b; }`
-    )
-
-    const add = snippet(
-      (name) =>
-        expr`float ${name}(float a, float b) { return a + ${mul}(b, 2.0); }`
-    )
-
-    const a = Float(1)
-    const b = Float(2)
-
-    const c = Vec3(new Color("hotpink"))
-
     const noise = Simplex3DNoise(VertexPosition)
 
     return CustomShaderMaterialMaster({

--- a/apps/examples/src/examples/Playground.tsx
+++ b/apps/examples/src/examples/Playground.tsx
@@ -5,9 +5,11 @@ import {
   Float,
   Fresnel,
   Multiply,
+  Simplex3DNoise,
   Smoothstep,
   Time,
-  Vec3
+  Vec3,
+  VertexPosition
 } from "shadenfreude"
 import { Color, DoubleSide, MeshStandardMaterial } from "three"
 import CustomShaderMaterial from "three-custom-shader-material"
@@ -25,8 +27,11 @@ export default function Playground() {
 
     const t = Time
 
+    const noise = Smoothstep(0, 0.1, Simplex3DNoise(VertexPosition))
+
     return CustomShaderMaterialMaster({
-      diffuseColor: Add(color, Multiply(fresnelColor, Fresnel()))
+      diffuseColor: Add(color, Multiply(fresnelColor, Fresnel())),
+      alpha: noise
     })
   }, [])
 

--- a/apps/examples/src/examples/Playground.tsx
+++ b/apps/examples/src/examples/Playground.tsx
@@ -3,14 +3,12 @@ import {
   CustomShaderMaterialMaster,
   expr,
   Float,
-  Fresnel,
   Mix,
   Multiply,
   Pipe,
   Pow,
   Remap,
   Simplex3DNoise,
-  Sin,
   Smoothstep,
   Step,
   Time,
@@ -20,7 +18,6 @@ import {
 import { Color, DoubleSide, MeshStandardMaterial } from "three"
 import CustomShaderMaterial from "three-custom-shader-material"
 import { DustExample } from "./DustExample"
-import { Fog } from "./Fog"
 import { useShader } from "./useShader"
 
 export default function Playground() {
@@ -44,7 +41,8 @@ export default function Playground() {
 
       diffuseColor: Pipe(
         Vec3(new Color("#66c")),
-        ($) => Mix($, new Color("#ec5"), Step(waterHeight, noise)),
+        ($) => Mix($, new Color("#68f"), Step(waterHeight, noise)),
+        ($) => Mix($, new Color("#ec5"), Step(Add(waterHeight, 0.02), noise)),
         ($) => Mix($, new Color("#494"), Step(0.34, noise)),
         ($) => Mix($, new Color("#ccc"), Step(0.5, noise)),
         ($) => Mix($, new Color("#fff"), Step(0.7, noise))

--- a/apps/examples/src/examples/Playground.tsx
+++ b/apps/examples/src/examples/Playground.tsx
@@ -13,6 +13,13 @@ export default function Playground() {
     const b = Float(2)
 
     return Float(expr`${add}(${a}, ${b})`)
+
+    // const noise = Simplex3DNoise(VertexPosition)
+
+    // return CustomShaderMaterialMaster({
+    //   diffuseColor: new Color("hotpink"),
+    //   alpha: noise
+    // })
   }, [])
 
   console.log(shader.vertexShader)

--- a/apps/examples/src/examples/Playground.tsx
+++ b/apps/examples/src/examples/Playground.tsx
@@ -7,6 +7,8 @@ import {
   Mix,
   Multiply,
   Pipe,
+  Pow,
+  Remap,
   Simplex3DNoise,
   Sin,
   Smoothstep,
@@ -23,25 +25,29 @@ import { useShader } from "./useShader"
 
 export default function Playground() {
   const shader = useShader(() => {
-    const noise = Simplex3DNoise(Vec3(Multiply(VertexPosition, 0.11)))
+    const noise = Pow(
+      Remap(Simplex3DNoise(Vec3(Multiply(VertexPosition, 0.11))), -1, 1, 0, 1),
+      1.5
+    )
 
-    const steppedNoise = Smoothstep(-0.1, 0.1, noise)
+    const steppedNoise = Smoothstep(-0, 1, noise)
 
     const waterHeight = Float(
-      expr`-0.1 + sin(${Time} + ${VertexPosition}.y) * 0.02`
+      expr`0.3 + sin(${Time} + ${VertexPosition}.y) * 0.02`
     )
 
     return CustomShaderMaterialMaster({
-      position: Pipe(VertexPosition, ($) =>
-        Vec3(expr`${$} * (1.0 + ${steppedNoise} * 0.3)`)
+      position: Multiply(
+        VertexPosition,
+        Float(expr`1.0 + ${steppedNoise} * 0.3`)
       ),
 
       diffuseColor: Pipe(
         Vec3(new Color("#66c")),
         ($) => Mix($, new Color("#ec5"), Step(waterHeight, noise)),
-        ($) => Mix($, new Color("#494"), Step(0, noise)),
-        ($) => Mix($, new Color("#ccc"), Step(0.3, noise)),
-        ($) => Mix($, new Color("#fff"), Step(0.5, noise))
+        ($) => Mix($, new Color("#494"), Step(0.34, noise)),
+        ($) => Mix($, new Color("#ccc"), Step(0.5, noise)),
+        ($) => Mix($, new Color("#fff"), Step(0.7, noise))
       )
     })
   }, [])

--- a/apps/examples/src/examples/Playground.tsx
+++ b/apps/examples/src/examples/Playground.tsx
@@ -1,6 +1,7 @@
 import {
   Add,
   CustomShaderMaterialMaster,
+  Dissolve,
   expr,
   Float,
   Mix,
@@ -10,6 +11,7 @@ import {
   Pow,
   Remap,
   Simplex3DNoise,
+  Sin,
   Smoothstep,
   Step,
   Sub,
@@ -20,6 +22,7 @@ import {
 } from "shadenfreude"
 import { Color, DoubleSide, MeshStandardMaterial } from "three"
 import CustomShaderMaterial from "three-custom-shader-material"
+import { smootherstep } from "three/src/math/MathUtils"
 import { DustExample } from "./DustExample"
 import { useShader } from "./useShader"
 
@@ -41,6 +44,8 @@ export default function Playground() {
       Simplex3DNoise(Add(Vec3(Mul(VertexPosition, 0.3)), Mul(Time, 0.05)))
     )
 
+    const dissolve = Dissolve(Smoothstep(-0.5, 0.5, Sin(Time)), 0.1)
+
     return CustomShaderMaterialMaster({
       position: Mul(VertexPosition, Float(expr`1.0 + ${steppedNoise} * 0.3`)),
 
@@ -57,8 +62,11 @@ export default function Playground() {
         /* Mountains */
         ($) => Mix($, new Color("#ccc"), Step(0.5, noise)),
         /* Skyrim */
-        ($) => Mix($, new Color("#fff"), Step(0.7, noise))
-      )
+        ($) => Mix($, new Color("#fff"), Step(0.7, noise)),
+        ($) => Add($, dissolve.color)
+      ),
+
+      alpha: dissolve.alpha
     })
   }, [])
 

--- a/apps/examples/src/examples/Playground.tsx
+++ b/apps/examples/src/examples/Playground.tsx
@@ -25,16 +25,20 @@ export default function Playground() {
     const a = Float(1)
     const b = Float(2)
 
+    const foo = Float(a)
+
+    return foo
+
     const c = Vec3(new Color("hotpink"))
 
     // return Float(expr`${add}(${a}, ${b})`)
 
     const noise = Simplex3DNoise(VertexPosition)
 
-    return CustomShaderMaterialMaster({
-      diffuseColor: new Color("hotpink"),
-      alpha: noise
-    })
+    // return CustomShaderMaterialMaster({
+    //   diffuseColor: new Color("hotpink"),
+    //   alpha: noise
+    // })
   }, [])
 
   // console.log(shader.vertexShader)

--- a/apps/examples/src/examples/Playground.tsx
+++ b/apps/examples/src/examples/Playground.tsx
@@ -36,23 +36,18 @@ export default function Playground() {
       expr`0.3 + sin(${Time} + ${VertexPosition}.y) * 0.02`
     )
 
+    const waterNoise = Step(
+      0,
+      Simplex3DNoise(Add(Vec3(Mul(VertexPosition, 0.3)), Mul(Time, 0.05)))
+    )
+
     return CustomShaderMaterialMaster({
       position: Mul(VertexPosition, Float(expr`1.0 + ${steppedNoise} * 0.3`)),
 
       diffuseColor: Pipe(
         Vec3(new Color("#66c")),
         /* Water noise yooooo */
-        ($) =>
-          Mix(
-            $,
-            new Color("#67d"),
-            Step(
-              0,
-              Simplex3DNoise(
-                Add(Vec3(Mul(VertexPosition, 0.3)), Mul(Time, 0.05))
-              )
-            )
-          ),
+        ($) => Mix($, new Color("#67d"), waterNoise),
         /* Foam */
         ($) => Mix($, new Color("#ddf"), Step(Sub(waterHeight, 0.02), noise)),
         /* Sand */

--- a/apps/examples/src/examples/Playground.tsx
+++ b/apps/examples/src/examples/Playground.tsx
@@ -17,6 +17,8 @@ import {
 } from "shadenfreude"
 import { Color, DoubleSide, MeshStandardMaterial } from "three"
 import CustomShaderMaterial from "three-custom-shader-material"
+import { DustExample } from "./DustExample"
+import { Fog } from "./Fog"
 import { useShader } from "./useShader"
 
 export default function Playground() {
@@ -49,6 +51,8 @@ export default function Playground() {
 
   return (
     <group position-y={18}>
+      <Fog />
+      <DustExample />
       <mesh>
         <icosahedronGeometry args={[12, 4]} />
 

--- a/apps/examples/src/examples/Playground.tsx
+++ b/apps/examples/src/examples/Playground.tsx
@@ -1,38 +1,20 @@
-import {
-  Add,
-  CustomShaderMaterialMaster,
-  Divide,
-  expr,
-  Float,
-  Fresnel,
-  Multiply,
-  Simplex3DNoise,
-  Smoothstep,
-  Time,
-  Vec3,
-  VertexPosition
-} from "shadenfreude"
-import { Color, DoubleSide, MeshStandardMaterial } from "three"
+import { expr, Float, snippet } from "shadenfreude"
+import { DoubleSide, MeshStandardMaterial } from "three"
 import CustomShaderMaterial from "three-custom-shader-material"
 import { useShader } from "./useShader"
+
+const snip = snippet(
+  (name) => `float ${name}(float a, float b) { return a + b; }`
+)
 
 export default function Playground() {
   const shader = useShader(() => {
     const a = Float(1)
     const b = Float(2)
 
-    // return Float(expr`${a} + ${b}`)
-
-    const t = Time
-
-    const noise = Smoothstep(
-      0,
-      0.01,
-      Simplex3DNoise(Divide(VertexPosition, 10))
-    )
-
-    return CustomShaderMaterialMaster({
-      diffuseColor: Add(new Color("#8f8"), Multiply(new Color("#88f"), noise))
+    return Float(expr`${snip}(${a}, ${b})`, {
+      vertexHeader: [snip],
+      fragmentHeader: [snip]
     })
   }, [])
 

--- a/apps/examples/src/examples/Playground.tsx
+++ b/apps/examples/src/examples/Playground.tsx
@@ -1,8 +1,10 @@
 import {
   CustomShaderMaterialMaster,
   expr,
+  float,
   Float,
   Simplex3DNoise,
+  Smoothstep,
   snippet,
   Vec3,
   VertexPosition
@@ -25,20 +27,14 @@ export default function Playground() {
     const a = Float(1)
     const b = Float(2)
 
-    const foo = Float(a)
-
-    return foo
-
     const c = Vec3(new Color("hotpink"))
-
-    // return Float(expr`${add}(${a}, ${b})`)
 
     const noise = Simplex3DNoise(VertexPosition)
 
-    // return CustomShaderMaterialMaster({
-    //   diffuseColor: new Color("hotpink"),
-    //   alpha: noise
-    // })
+    return CustomShaderMaterialMaster({
+      diffuseColor: new Color("hotpink"),
+      alpha: Smoothstep(0.0, 0.2, noise)
+    })
   }, [])
 
   // console.log(shader.vertexShader)

--- a/apps/examples/src/examples/Playground.tsx
+++ b/apps/examples/src/examples/Playground.tsx
@@ -41,10 +41,27 @@ export default function Playground() {
 
       diffuseColor: Pipe(
         Vec3(new Color("#66c")),
-        ($) => Mix($, new Color("#68f"), Step(Sub(waterHeight, 0.02), noise)),
+        /* Water noise yooooo */
+        ($) =>
+          Mix(
+            $,
+            new Color("#67d"),
+            Step(
+              0,
+              Simplex3DNoise(
+                Add(Vec3(Mul(VertexPosition, 0.5)), Mul(Time, 0.15))
+              )
+            )
+          ),
+        /* Foam */
+        ($) => Mix($, new Color("#ddf"), Step(Sub(waterHeight, 0.02), noise)),
+        /* Sand */
         ($) => Mix($, new Color("#ec5"), Step(waterHeight, noise)),
+        /* Green */
         ($) => Mix($, new Color("#494"), Step(0.34, noise)),
+        /* Mountains */
         ($) => Mix($, new Color("#ccc"), Step(0.5, noise)),
+        /* Skyrim */
         ($) => Mix($, new Color("#fff"), Step(0.7, noise))
       )
     })

--- a/apps/examples/src/examples/Playground.tsx
+++ b/apps/examples/src/examples/Playground.tsx
@@ -1,7 +1,6 @@
 import {
   CustomShaderMaterialMaster,
   expr,
-  float,
   Float,
   Simplex3DNoise,
   Smoothstep,

--- a/apps/examples/src/examples/Playground.tsx
+++ b/apps/examples/src/examples/Playground.tsx
@@ -1,8 +1,9 @@
 import {
+  Add,
   CustomShaderMaterialMaster,
   expr,
   Float,
-  Join,
+  Fresnel,
   Multiply,
   Smoothstep,
   Time,
@@ -18,13 +19,14 @@ export default function Playground() {
     const b = Float(2)
 
     const color = Vec3(new Color("hotpink"))
+    const fresnelColor = Vec3(new Color(2, 2, 2))
 
     // return Float(expr`${a} + ${b}`)
 
     const t = Time
 
     return CustomShaderMaterialMaster({
-      diffuseColor: Join(t, t, t)
+      diffuseColor: Add(color, Multiply(fresnelColor, Fresnel()))
     })
   }, [])
 

--- a/apps/examples/src/examples/Playground.tsx
+++ b/apps/examples/src/examples/Playground.tsx
@@ -14,7 +14,7 @@ export default function Playground() {
 
     // return Float(expr`${add}(${a}, ${b})`)
 
-    return Float(expr`1.0 + 1.0`)
+    return Float(expr`${a} + ${b}`)
 
     // const noise = Simplex3DNoise(VertexPosition)
 

--- a/apps/examples/src/examples/Playground.tsx
+++ b/apps/examples/src/examples/Playground.tsx
@@ -1,4 +1,12 @@
-import { expr, Float, snippet, Vec3 } from "shadenfreude"
+import {
+  CustomShaderMaterialMaster,
+  expr,
+  Float,
+  Simplex3DNoise,
+  snippet,
+  Vec3,
+  VertexPosition
+} from "shadenfreude"
 import { Color, DoubleSide, MeshStandardMaterial } from "three"
 import CustomShaderMaterial from "three-custom-shader-material"
 import { useShader } from "./useShader"
@@ -19,14 +27,14 @@ export default function Playground() {
 
     const c = Vec3(new Color("hotpink"))
 
-    return Float(expr`${add}(${a}, ${b})`)
+    // return Float(expr`${add}(${a}, ${b})`)
 
-    // const noise = Simplex3DNoise(VertexPosition)
+    const noise = Simplex3DNoise(VertexPosition)
 
-    // return CustomShaderMaterialMaster({
-    //   diffuseColor: new Color("hotpink"),
-    //   alpha: noise
-    // })
+    return CustomShaderMaterialMaster({
+      diffuseColor: new Color("hotpink"),
+      alpha: noise
+    })
   }, [])
 
   // console.log(shader.vertexShader)

--- a/apps/examples/src/examples/Playground.tsx
+++ b/apps/examples/src/examples/Playground.tsx
@@ -12,7 +12,9 @@ export default function Playground() {
     const a = Float(1)
     const b = Float(2)
 
-    return Float(expr`${add}(${a}, ${b})`)
+    // return Float(expr`${add}(${a}, ${b})`)
+
+    return Float(expr`1.0 + 1.0`)
 
     // const noise = Simplex3DNoise(VertexPosition)
 

--- a/apps/examples/src/examples/Playground.tsx
+++ b/apps/examples/src/examples/Playground.tsx
@@ -25,7 +25,7 @@ export default function Playground() {
   const shader = useShader(() => {
     const noise = Simplex3DNoise(Vec3(Multiply(VertexPosition, 0.11)))
 
-    const steppedNoise = Smoothstep(-0.5, 0.5, noise)
+    const steppedNoise = Smoothstep(-0.1, 0.1, noise)
 
     const waterHeight = Float(
       expr`-0.1 + sin(${Time} + ${VertexPosition}.y) * 0.02`
@@ -51,7 +51,7 @@ export default function Playground() {
 
   return (
     <group position-y={18}>
-      <Fog />
+      {/* <Fog /> */}
       <DustExample />
       <mesh>
         <icosahedronGeometry args={[12, 4]} />

--- a/apps/examples/src/examples/Playground.tsx
+++ b/apps/examples/src/examples/Playground.tsx
@@ -1,6 +1,7 @@
 import {
   Add,
   CustomShaderMaterialMaster,
+  Divide,
   expr,
   Float,
   Fresnel,
@@ -20,18 +21,18 @@ export default function Playground() {
     const a = Float(1)
     const b = Float(2)
 
-    const color = Vec3(new Color("hotpink"))
-    const fresnelColor = Vec3(new Color(2, 2, 2))
-
     // return Float(expr`${a} + ${b}`)
 
     const t = Time
 
-    const noise = Smoothstep(0, 0.1, Simplex3DNoise(VertexPosition))
+    const noise = Smoothstep(
+      0,
+      0.01,
+      Simplex3DNoise(Divide(VertexPosition, 10))
+    )
 
     return CustomShaderMaterialMaster({
-      diffuseColor: Add(color, Multiply(fresnelColor, Fresnel())),
-      alpha: noise
+      diffuseColor: Add(new Color("#8f8"), Multiply(new Color("#88f"), noise))
     })
   }, [])
 
@@ -48,8 +49,8 @@ export default function Playground() {
           {...shader}
           transparent
           side={DoubleSide}
-          metalness={0.5}
-          roughness={0.5}
+          metalness={0}
+          roughness={0}
         />
       </mesh>
     </group>

--- a/apps/examples/src/examples/Playground.tsx
+++ b/apps/examples/src/examples/Playground.tsx
@@ -3,19 +3,16 @@ import { DoubleSide, MeshStandardMaterial } from "three"
 import CustomShaderMaterial from "three-custom-shader-material"
 import { useShader } from "./useShader"
 
-const snip = snippet(
-  (name) => `float ${name}(float a, float b) { return a + b; }`
-)
-
 export default function Playground() {
   const shader = useShader(() => {
+    const add = snippet(
+      (name) => `float ${name}(float a, float b) { return a + b; }`
+    )
+
     const a = Float(1)
     const b = Float(2)
 
-    return Float(expr`${snip}(${a}, ${b})`, {
-      vertexHeader: [snip],
-      fragmentHeader: [snip]
-    })
+    return Float(expr`${add}(${a}, ${b})`)
   }, [])
 
   console.log(shader.vertexShader)

--- a/apps/examples/src/examples/Playground.tsx
+++ b/apps/examples/src/examples/Playground.tsx
@@ -49,7 +49,7 @@ export default function Playground() {
             Step(
               0,
               Simplex3DNoise(
-                Add(Vec3(Mul(VertexPosition, 0.5)), Mul(Time, 0.15))
+                Add(Vec3(Mul(VertexPosition, 0.3)), Mul(Time, 0.05))
               )
             )
           ),

--- a/apps/examples/src/examples/Playground.tsx
+++ b/apps/examples/src/examples/Playground.tsx
@@ -1,12 +1,11 @@
 import {
   Add,
+  code,
   CustomShaderMaterialMaster,
   Dissolve,
-  code,
   Float,
   Mix,
   Mul,
-  Multiply,
   Pipe,
   Pow,
   Remap,
@@ -15,14 +14,12 @@ import {
   Smoothstep,
   Step,
   Sub,
-  Subtract,
   Time,
   Vec3,
   VertexPosition
 } from "shadenfreude"
 import { Color, DoubleSide, MeshStandardMaterial } from "three"
 import CustomShaderMaterial from "three-custom-shader-material"
-import { smootherstep } from "three/src/math/MathUtils"
 import { DustExample } from "./DustExample"
 import { useShader } from "./useShader"
 

--- a/apps/examples/src/examples/Playground.tsx
+++ b/apps/examples/src/examples/Playground.tsx
@@ -1,7 +1,11 @@
 import {
   CustomShaderMaterialMaster,
+  expr,
+  Mix,
+  Pipe,
   Simplex3DNoise,
   Smoothstep,
+  Vec3,
   VertexPosition
 } from "shadenfreude"
 import { Color, DoubleSide, MeshStandardMaterial } from "three"
@@ -10,11 +14,16 @@ import { useShader } from "./useShader"
 
 export default function Playground() {
   const shader = useShader(() => {
-    const noise = Simplex3DNoise(VertexPosition)
+    const noise = Simplex3DNoise(Vec3(expr`${VertexPosition} * 0.1`))
+
+    const steppedNoise = Smoothstep(0, 0.1, noise)
 
     return CustomShaderMaterialMaster({
-      diffuseColor: new Color("hotpink"),
-      alpha: Smoothstep(0.0, 0.2, noise)
+      position: Pipe(VertexPosition, ($) =>
+        Vec3(expr`${$} * (1.0 + ${steppedNoise} * 0.3)`)
+      ),
+
+      diffuseColor: Mix(new Color("#333"), new Color("hotpink"), steppedNoise)
     })
   }, [])
 
@@ -24,7 +33,7 @@ export default function Playground() {
   return (
     <group position-y={15}>
       <mesh>
-        <icosahedronGeometry args={[12, 8]} />
+        <icosahedronGeometry args={[12, 24]} />
 
         <CustomShaderMaterial
           baseMaterial={MeshStandardMaterial}

--- a/apps/examples/src/examples/Playground.tsx
+++ b/apps/examples/src/examples/Playground.tsx
@@ -25,8 +25,10 @@ import { useShader } from "./useShader"
 
 export default function Playground() {
   const shader = useShader(() => {
+    const scaledPos = Vec3(Mul(VertexPosition, 0.11))
+
     const noise = Pow(
-      Remap(Simplex3DNoise(Vec3(Mul(VertexPosition, 0.11))), -1, 1, 0, 1),
+      Remap(Simplex3DNoise(code`${scaledPos}`), -1, 1, 0, 1),
       1.5
     )
 

--- a/apps/examples/src/examples/Playground.tsx
+++ b/apps/examples/src/examples/Playground.tsx
@@ -16,8 +16,8 @@ export default function Playground() {
 
     // return Float(expr`${add}(${a}, ${b})`)
 
-    return Float(expr`${a} + ${b}`, {
-      fragmentBody: `csm_DiffuseColor = vec4(1.0, 0.5, 0.2, 1.0);`
+    return Float(expr`1.0 + 1.0`, {
+      fragmentBody: expr`csm_DiffuseColor = vec4(${a}, 0.5, 0.2, 1.0);`
     })
 
     // const noise = Simplex3DNoise(VertexPosition)

--- a/apps/examples/src/examples/Playground.tsx
+++ b/apps/examples/src/examples/Playground.tsx
@@ -5,8 +5,13 @@ import { useShader } from "./useShader"
 
 export default function Playground() {
   const shader = useShader(() => {
+    const mul = snippet(
+      (name) => `float ${name}(float a, float b) { return a * b; }`
+    )
+
     const add = snippet(
-      (name) => `float ${name}(float a, float b) { return a + b; }`
+      (name) =>
+        expr`float ${name}(float a, float b) { return a + ${mul}(b, 2.0); }`
     )
 
     const a = Float(1)
@@ -14,11 +19,7 @@ export default function Playground() {
 
     const c = Vec3(new Color("hotpink"))
 
-    // return Float(expr`${add}(${a}, ${b})`)
-
-    return Float(expr`1.0 + 1.0`, {
-      fragmentBody: [expr`csm_DiffuseColor = vec4(${a}, 0.5, 0.2, 1.0);`]
-    })
+    return Float(expr`${add}(${a}, ${b})`)
 
     // const noise = Simplex3DNoise(VertexPosition)
 

--- a/apps/examples/src/examples/Playground.tsx
+++ b/apps/examples/src/examples/Playground.tsx
@@ -17,7 +17,7 @@ export default function Playground() {
     // return Float(expr`${add}(${a}, ${b})`)
 
     return Float(expr`1.0 + 1.0`, {
-      fragmentBody: expr`csm_DiffuseColor = vec4(${a}, 0.5, 0.2, 1.0);`
+      fragmentBody: [expr`csm_DiffuseColor = vec4(${a}, 0.5, 0.2, 1.0);`]
     })
 
     // const noise = Simplex3DNoise(VertexPosition)

--- a/packages/shadenfreude/src/__snapshots__/compilers.test.ts.snap
+++ b/packages/shadenfreude/src/__snapshots__/compilers.test.ts.snap
@@ -1,35 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`compileShader doesn't render the same dependency twice 1`] = `
-"void main()
-{
-  /*** BEGIN: anon (1) ***/
-  float float_anon_1;
-  {
-    float value = 1.0;
-    float_anon_1 = value;
-  }
-  /*** END: anon (1) ***/
-
-  /*** BEGIN: anon (2) ***/
-  float float_anon_2;
-  {
-    float value = float_anon_1;
-    float_anon_2 = value;
-  }
-  /*** END: anon (2) ***/
-
-  /*** BEGIN: anon (3) ***/
-  float float_anon_3;
-  {
-    float value = float_anon_1 + float_anon_2;
-    float_anon_3 = value;
-  }
-  /*** END: anon (3) ***/
-
-}"
-`;
-
 exports[`compileShader includes the variable's chunks if it has them 1`] = `
 "/*** BEGIN: anon (1) ***/
 uniform float u_time;
@@ -64,28 +34,6 @@ void main()
     float_anon_1 = value;
   }
   /*** END: anon (1) ***/
-
-}"
-`;
-
-exports[`compileShader resolves dependencies to other variables 1`] = `
-"void main()
-{
-  /*** BEGIN: anon (1) ***/
-  float float_anon_1;
-  {
-    float value = 1.0;
-    float_anon_1 = value;
-  }
-  /*** END: anon (1) ***/
-
-  /*** BEGIN: anon (2) ***/
-  float float_anon_2;
-  {
-    float value = float_anon_1;
-    float_anon_2 = value;
-  }
-  /*** END: anon (2) ***/
 
 }"
 `;

--- a/packages/shadenfreude/src/__snapshots__/compilers.test.ts.snap
+++ b/packages/shadenfreude/src/__snapshots__/compilers.test.ts.snap
@@ -12,18 +12,18 @@ exports[`compileShader doesn't render the same dependency twice 1`] = `
   /*** END: anon (1) ***/
 
   /*** BEGIN: anon (2) ***/
-  bool bool_anon_2;
+  float float_anon_2;
   {
-    bool value = true;
-    bool_anon_2 = value;
+    float value = float_anon_1;
+    float_anon_2 = value;
   }
   /*** END: anon (2) ***/
 
   /*** BEGIN: anon (3) ***/
-  bool bool_anon_3;
+  float float_anon_3;
   {
-    bool value = true;
-    bool_anon_3 = value;
+    float value = float_anon_1 + float_anon_2;
+    float_anon_3 = value;
   }
   /*** END: anon (3) ***/
 

--- a/packages/shadenfreude/src/compilers.test.ts
+++ b/packages/shadenfreude/src/compilers.test.ts
@@ -1,5 +1,5 @@
 import { compileShader } from "./compilers"
-import { expr } from "./expressions"
+import { code } from "./expressions"
 import { assignment, statement } from "./lib/concatenator3000"
 import { Bool, Float, Variable } from "./variables"
 
@@ -69,8 +69,8 @@ describe("compileShader", () => {
 
   it("doesn't render the same dependency twice", () => {
     const a = Float(1)
-    const b = Float(expr`${a}`)
-    const c = Float(expr`${a} + ${b}`)
+    const b = Float(code`${a}`)
+    const c = Float(code`${a} + ${b}`)
 
     const [shader] = compileShader(c)
 

--- a/packages/shadenfreude/src/compilers.test.ts
+++ b/packages/shadenfreude/src/compilers.test.ts
@@ -1,4 +1,5 @@
 import { compileShader } from "./compilers"
+import { expr } from "./expressions"
 import { assignment, statement } from "./lib/concatenator3000"
 import { Bool, Float, Variable } from "./variables"
 
@@ -38,21 +39,69 @@ describe("compileShader", () => {
   })
 
   it("resolves dependencies to other variables", () => {
-    const float = Variable("float", 1)
-    const root = Variable("float", float)
+    const a = Variable("float", 1)
+    const b = Variable("float", a)
 
-    const [shader] = compileShader(root)
+    const [shader] = compileShader(b)
 
-    expect(shader.vertexShader).toMatchSnapshot()
+    expect(shader.vertexShader).toMatchInlineSnapshot(`
+      "void main()
+      {
+        /*** BEGIN: anon (1) ***/
+        float float_anon_1;
+        {
+          float value = 1.0;
+          float_anon_1 = value;
+        }
+        /*** END: anon (1) ***/
+
+        /*** BEGIN: anon (2) ***/
+        float float_anon_2;
+        {
+          float value = float_anon_1;
+          float_anon_2 = value;
+        }
+        /*** END: anon (2) ***/
+
+      }"
+    `)
   })
 
   it("doesn't render the same dependency twice", () => {
     const a = Float(1)
-    const b = Bool(true, { dependencies: [a] })
-    const c = Bool(true, { dependencies: [a, b] })
+    const b = Float(expr`${a}`)
+    const c = Float(expr`${a} + ${b}`)
 
     const [shader] = compileShader(c)
 
-    expect(shader.fragmentShader).toMatchSnapshot()
+    expect(shader.fragmentShader).toMatchInlineSnapshot(`
+      "void main()
+      {
+        /*** BEGIN: anon (1) ***/
+        float float_anon_1;
+        {
+          float value = 1.0;
+          float_anon_1 = value;
+        }
+        /*** END: anon (1) ***/
+
+        /*** BEGIN: anon (2) ***/
+        float float_anon_2;
+        {
+          float value = float_anon_1;
+          float_anon_2 = value;
+        }
+        /*** END: anon (2) ***/
+
+        /*** BEGIN: anon (3) ***/
+        float float_anon_3;
+        {
+          float value = float_anon_1 + float_anon_2;
+          float_anon_3 = value;
+        }
+        /*** END: anon (3) ***/
+
+      }"
+    `)
   })
 })

--- a/packages/shadenfreude/src/compilers.ts
+++ b/packages/shadenfreude/src/compilers.ts
@@ -6,8 +6,10 @@ import {
   block,
   concatenate,
   flatten,
+  identifier,
   isSnippet,
   Parts,
+  sluggify,
   Snippet,
   statement
 } from "./lib/concatenator3000"
@@ -67,6 +69,10 @@ export const compileVariable = (
     isVariable(dep) && compileVariable(dep, program, state)
     isSnippet(dep) && compileSnippet(dep, program, state)
   })
+
+  /* Prepare this variable */
+  v._config.id = state.nextId()
+  v._config.name = identifier(v.type, sluggify(v._config.title), v._config.id)
 
   /* HEADER */
   const header = flatten(

--- a/packages/shadenfreude/src/compilers.ts
+++ b/packages/shadenfreude/src/compilers.ts
@@ -1,4 +1,5 @@
 import { Vector2 } from "three"
+import { isExpression } from "./expressions"
 import { glslRepresentation } from "./glslRepresentation"
 import {
   assignment,
@@ -38,6 +39,14 @@ export const compileVariable = (
 ) => {
   if (!state.freshVariable(v)) return []
   if (v._config.only && v._config.only !== program) return []
+
+  /* Build a list of dependencies */
+  const dependencies = isExpression(v.value) ? v.value.values : [v.value]
+
+  /* Render dependencies */
+  dependencies.forEach(
+    (dep) => isVariable(dep) && compileVariable(dep, program, state)
+  )
 
   /* HEADER */
   const header = flatten(

--- a/packages/shadenfreude/src/compilers.ts
+++ b/packages/shadenfreude/src/compilers.ts
@@ -6,10 +6,11 @@ import {
   concatenate,
   flatten,
   identifier,
-  isExpression,
+  isSnippet,
   Parts,
   resetConcatenator3000,
   sluggify,
+  Snippet,
   statement
 } from "./lib/concatenator3000"
 import idGenerator from "./lib/idGenerator"
@@ -39,7 +40,7 @@ export const compileHeader = (
 
   return [
     /* Render dependencies */
-    dependencies(v).map((dep) => compileHeader(dep, program, stack)),
+    variableDependencies(v).map((dep) => compileHeader(dep, program, stack)),
 
     /* Render header chunk */
     header.length && [variableBeginComment(v), header, variableEndComment(v)]
@@ -57,7 +58,7 @@ export const compileBody = (
 
   return [
     /* Render dependencies */
-    dependencies(v).map((dep) => compileBody(dep, program, stack)),
+    variableDependencies(v).map((dep) => compileBody(dep, program, stack)),
 
     variableBeginComment(v),
 
@@ -97,7 +98,7 @@ const prepare = (v: Variable, stack = dependencyStack()) => {
   if (!stack.fresh(v)) return
 
   /* Prepare dependencies first */
-  dependencies(v).forEach((d) => prepare(d, stack))
+  variableDependencies(v).forEach((d) => prepare(d, stack))
 
   /* Update the node's ID */
   v._config.id = stack.nextId()
@@ -138,7 +139,8 @@ const dependencyStack = () => {
   }
 }
 
-const dependencies = (v: Variable) =>
-  [isVariable(v.value) && v.value, ...v._config.dependencies].filter((d) =>
-    isVariable(d)
-  ) as Variable[]
+const variableDependencies = (v: Variable) =>
+  [isVariable(v.value) && v.value, ...v._config.dependencies].filter(isVariable)
+
+const snippetDependencies = (v: Variable) =>
+  v._config.dependencies.filter(isSnippet)

--- a/packages/shadenfreude/src/compilers.ts
+++ b/packages/shadenfreude/src/compilers.ts
@@ -32,6 +32,13 @@ const renderSnippet = (
   return s.chunk
 }
 
+const getDependencies = (...sources: any[]): Variable[] =>
+  sources
+    .map((s) => (isExpression(s) ? s.values : undefined))
+    // .map((s) => (Array.isArray(s) ? getDependencies(...s) : undefined))
+    .flat()
+    .filter((d) => !!d)
+
 export const compileVariable = (
   v: Variable,
   program: ProgramType,
@@ -41,7 +48,7 @@ export const compileVariable = (
   if (v._config.only && v._config.only !== program) return []
 
   /* Build a list of dependencies */
-  const dependencies = isExpression(v.value) ? v.value.values : []
+  const dependencies = getDependencies(v.value, v._config.fragmentBody)
 
   /* Render dependencies */
   dependencies.forEach(

--- a/packages/shadenfreude/src/compilers.ts
+++ b/packages/shadenfreude/src/compilers.ts
@@ -31,16 +31,24 @@ export const compileHeader = (
 ): Parts => {
   if (!stack.fresh(v)) return []
 
+  /* Abort if we're not supposed to render this in the current program. */
   if (v._config.only && v._config.only !== program) return []
 
+  /* Compose the header */
   const header = flatten(
+    /* If this variable is configured to use a varying, declare it */
     v._config.varying && `varying ${v.type} v_${v._config.name};`,
+
+    /* Render the actual header chuink */
     v._config[`${program}Header`]
   )
 
   return [
-    /* Render dependencies */
+    /* Render variable dependencies */
     variableDependencies(v).map((dep) => compileHeader(dep, program, stack)),
+
+    /* Render snippet dependencies */
+    snippetDependencies(v).map((snip) => snip),
 
     /* Render header chunk */
     header.length && [variableBeginComment(v), header, variableEndComment(v)]

--- a/packages/shadenfreude/src/compilers.ts
+++ b/packages/shadenfreude/src/compilers.ts
@@ -41,7 +41,7 @@ export const compileVariable = (
   if (v._config.only && v._config.only !== program) return []
 
   /* Build a list of dependencies */
-  const dependencies = isExpression(v.value) ? v.value.values : [v.value]
+  const dependencies = isExpression(v.value) ? v.value.values : []
 
   /* Render dependencies */
   dependencies.forEach(

--- a/packages/shadenfreude/src/compilers.ts
+++ b/packages/shadenfreude/src/compilers.ts
@@ -32,12 +32,13 @@ const renderSnippet = (
   return s.chunk
 }
 
-const getDependencies = (...sources: any[]): Variable[] =>
-  sources
+const deepFlat = (parts: Parts): Parts =>
+  parts.map((p) => (Array.isArray(p) ? deepFlat(p) : p))
+
+const getDependencies = (...sources: any[]): any[] =>
+  deepFlat(sources)
     .map((s) => (isExpression(s) ? s.values : undefined))
-    // .map((s) => (Array.isArray(s) ? getDependencies(...s) : undefined))
     .flat()
-    .filter((d) => !!d)
 
 export const compileVariable = (
   v: Variable,
@@ -49,6 +50,8 @@ export const compileVariable = (
 
   /* Build a list of dependencies */
   const dependencies = getDependencies(v.value, v._config.fragmentBody)
+
+  console.log(dependencies)
 
   /* Render dependencies */
   dependencies.forEach(

--- a/packages/shadenfreude/src/compilers.ts
+++ b/packages/shadenfreude/src/compilers.ts
@@ -24,6 +24,13 @@ const variableBeginComment = (v: Variable) =>
 const variableEndComment = (v: Variable) =>
   `/*** END: ${v._config.title} (${v._config.id}) ***/\n`
 
+/**
+ * Traverses the specified variables and returns a list of all objects that can
+ * be dependencies of something else (variables, expressions, snippets, etc.)
+ *
+ * @param sources
+ * @returns
+ */
 const getDependencies = (...sources: any[]): any[] =>
   sources
     .flat(Infinity)
@@ -152,10 +159,8 @@ export const compileShader = (root: Variable) => {
 
 const compilerState = () => {
   const seen = new Set<Variable | Snippet>()
-
   const header = [] as Parts
   const body = [] as Parts
-
   const nextId = idGenerator()
 
   return {

--- a/packages/shadenfreude/src/compilers.ts
+++ b/packages/shadenfreude/src/compilers.ts
@@ -27,7 +27,15 @@ const variableEndComment = (v: Variable) =>
 const getDependencies = (...sources: any[]): any[] =>
   sources
     .flat(Infinity)
-    .map((s) => (isExpression(s) ? s.values : isSnippet(s) ? s : undefined))
+    .map((s) =>
+      isVariable(s)
+        ? s
+        : isExpression(s)
+        ? s.values
+        : isSnippet(s)
+        ? s
+        : undefined
+    )
     .flat()
     .filter((d) => !!d)
 
@@ -44,7 +52,7 @@ const compileSnippet = (
       isSnippet(v) && compileSnippet(v, program, state)
     })
 
-  state.header.push(s.chunk)
+  state.header.push(`/*** SNIPPET: ${s.name} ***/`, s.chunk)
 }
 
 export const compileVariable = (

--- a/packages/shadenfreude/src/compilers.ts
+++ b/packages/shadenfreude/src/compilers.ts
@@ -32,13 +32,12 @@ const renderSnippet = (
   return s.chunk
 }
 
-const deepFlat = (parts: Parts): Parts =>
-  parts.map((p) => (Array.isArray(p) ? deepFlat(p) : p))
-
 const getDependencies = (...sources: any[]): any[] =>
-  deepFlat(sources)
+  sources
+    .flat(Infinity)
     .map((s) => (isExpression(s) ? s.values : undefined))
     .flat()
+    .filter((d) => !!d)
 
 export const compileVariable = (
   v: Variable,
@@ -49,9 +48,13 @@ export const compileVariable = (
   if (v._config.only && v._config.only !== program) return []
 
   /* Build a list of dependencies */
-  const dependencies = getDependencies(v.value, v._config.fragmentBody)
-
-  console.log(dependencies)
+  const dependencies = getDependencies(
+    v.value,
+    v._config.fragmentHeader,
+    v._config.fragmentBody,
+    v._config.vertexHeader,
+    v._config.vertexBody
+  )
 
   /* Render dependencies */
   dependencies.forEach(
@@ -106,8 +109,6 @@ export const compileVariable = (
 export const compileProgram = (v: Variable, program: ProgramType) => {
   const state = compilerState()
   compileVariable(v, program, state)
-
-  console.log(state)
 
   return concatenate(state.header, "void main()", block(state.body))
 }

--- a/packages/shadenfreude/src/compilers.ts
+++ b/packages/shadenfreude/src/compilers.ts
@@ -62,14 +62,11 @@ export const compileVariable = (
     v._config.vertexBody
   )
 
-  /* Render variable dependencies */
-  dependencies.forEach(
-    (dep) => isVariable(dep) && compileVariable(dep, program, state)
-  )
-
-  dependencies
-    .filter(isSnippet)
-    .forEach((s) => compileSnippet(s, program, state))
+  /* Render variable and snippet dependencies */
+  dependencies.forEach((dep) => {
+    isVariable(dep) && compileVariable(dep, program, state)
+    isSnippet(dep) && compileSnippet(dep, program, state)
+  })
 
   /* HEADER */
   const header = flatten(
@@ -86,7 +83,6 @@ export const compileVariable = (
   )
 
   /* BODY */
-
   state.body.push(
     variableBeginComment(v),
 

--- a/packages/shadenfreude/src/compilers.ts
+++ b/packages/shadenfreude/src/compilers.ts
@@ -53,7 +53,7 @@ export const compileVariable = (
   if (!state.isFresh(v)) return []
   if (v._config.only && v._config.only !== program) return []
 
-  /* Build a list of dependencies */
+  /* Build a list of dependencies from the various places that can have them: */
   const dependencies = getDependencies(
     v.value,
     v._config.fragmentHeader,
@@ -61,8 +61,6 @@ export const compileVariable = (
     v._config.vertexHeader,
     v._config.vertexBody
   )
-
-  console.log("DEPS:", dependencies)
 
   /* Render variable dependencies */
   dependencies.forEach(

--- a/packages/shadenfreude/src/compilers.ts
+++ b/packages/shadenfreude/src/compilers.ts
@@ -89,6 +89,7 @@ export const compileVariable = (
   )
 }
 
+/**  Compile a program from the variable */
 export const compileProgram = (v: Variable, program: ProgramType) => {
   const state = compilerState()
   compileVariable(v, program, state)
@@ -113,7 +114,6 @@ export const compileShader = (root: Variable) => {
   prepare(root)
 
   const vertexShader = compileProgram(root, "vertex")
-
   const fragmentShader = compileProgram(root, "fragment")
 
   const uniforms = {

--- a/packages/shadenfreude/src/compilers.ts
+++ b/packages/shadenfreude/src/compilers.ts
@@ -28,7 +28,7 @@ const renderSnippet = (
   stack: ReturnType<typeof dependencyStack>
 ): Parts => {
   if (!stack.freshSnippet(s)) return []
-  return [s.dependencies.map((s) => renderSnippet(s, stack)), s.chunk]
+  return s.chunk
 }
 
 export const compileHeader = (

--- a/packages/shadenfreude/src/compilers.ts
+++ b/packages/shadenfreude/src/compilers.ts
@@ -94,7 +94,9 @@ export const compileProgram = (v: Variable, program: ProgramType) => {
   const state = compilerState()
   compileVariable(v, program, state)
 
-  concatenate(state.header, "void main()", block(state.body))
+  console.log(state)
+
+  return concatenate(state.header, "void main()", block(state.body))
 }
 
 const prepare = (v: Variable, state = compilerState()) => {

--- a/packages/shadenfreude/src/compilers.ts
+++ b/packages/shadenfreude/src/compilers.ts
@@ -38,12 +38,12 @@ const getDependencies = (...sources: any[]): any[] =>
       isVariable(s)
         ? s
         : isExpression(s)
-        ? s.values
+        ? [s.values, getDependencies(...s.values)]
         : isSnippet(s)
         ? s
         : undefined
     )
-    .flat()
+    .flat(Infinity)
     .filter((d) => !!d)
 
 const compileSnippet = (

--- a/packages/shadenfreude/src/expressions.ts
+++ b/packages/shadenfreude/src/expressions.ts
@@ -14,8 +14,7 @@ export type Expression = {
   render: () => string
 }
 
-const zip = (a: TemplateStringsArray | any[], b: any[]) =>
-  a.map((k, i) => [k, b[i]])
+const zip = (a: TemplateStringsArray, b: any[]) => a.map((k, i) => [k, b[i]])
 
 export const expr = (
   strings: TemplateStringsArray,

--- a/packages/shadenfreude/src/expressions.ts
+++ b/packages/shadenfreude/src/expressions.ts
@@ -1,4 +1,5 @@
 import { glslRepresentation } from "./glslRepresentation"
+import { GLSLType, ValueFunction } from "./variables"
 
 const collectedDependencies = new Array<any>()
 
@@ -8,25 +9,16 @@ export const flushDependencies = () => {
   return deps
 }
 
-export type Expression = {
-  _: "Expression"
-  render: () => string
-}
-
 const zip = (a: TemplateStringsArray, b: any[]) => a.map((k, i) => [k, b[i]])
 
-export const expr = (
+export const expr = <T extends GLSLType>(
   strings: TemplateStringsArray,
   ...values: any[]
-): Expression => {
+): ValueFunction<T> => {
   collectedDependencies.push(...values)
 
-  return {
-    _: "Expression",
-
-    render: () =>
-      zip(strings, values.map(glslRepresentation))
-        .flat()
-        .join("")
-  }
+  return () =>
+    zip(strings, values.map(glslRepresentation))
+      .flat()
+      .join("")
 }

--- a/packages/shadenfreude/src/expressions.ts
+++ b/packages/shadenfreude/src/expressions.ts
@@ -1,24 +1,27 @@
 import { glslRepresentation } from "./glslRepresentation"
-import { GLSLType, ValueFunction } from "./variables"
 
-const collectedDependencies = new Array<any>()
-
-export const flushDependencies = () => {
-  const deps = [...collectedDependencies]
-  collectedDependencies.splice(0)
-  return deps
+export type Expression = {
+  _: "Expression"
+  values: any[]
+  render: () => string
 }
 
 const zip = (a: TemplateStringsArray, b: any[]) => a.map((k, i) => [k, b[i]])
 
-export const expr = <T extends GLSLType>(
+export const expr = (
   strings: TemplateStringsArray,
   ...values: any[]
-): ValueFunction => {
-  collectedDependencies.push(...values)
+): Expression => ({
+  _: "Expression",
 
-  return () =>
+  values,
+
+  render: () =>
     zip(strings, values.map(glslRepresentation))
       .flat()
       .join("")
+})
+
+export function isExpression(v: any): v is Expression {
+  return v && v._ === "Expression"
 }

--- a/packages/shadenfreude/src/expressions.ts
+++ b/packages/shadenfreude/src/expressions.ts
@@ -10,7 +10,6 @@ export const flushDependencies = () => {
 
 export type Expression = {
   _: "Expression"
-  values: any[]
   render: () => string
 }
 
@@ -24,8 +23,6 @@ export const expr = (
 
   return {
     _: "Expression",
-
-    values,
 
     render: () =>
       zip(strings, values.map(glslRepresentation))

--- a/packages/shadenfreude/src/expressions.ts
+++ b/packages/shadenfreude/src/expressions.ts
@@ -1,5 +1,4 @@
 import { glslRepresentation } from "./glslRepresentation"
-import { Float } from "./variables"
 
 export type Expression = {
   _: "Expression"
@@ -26,8 +25,3 @@ export const expr = (
 export function isExpression(v: any): v is Expression {
   return v && v._ === "Expression"
 }
-
-/* Type expression helpers */
-
-export const float = (strings: TemplateStringsArray, ...values: any[]) =>
-  Float(expr(strings, ...values))

--- a/packages/shadenfreude/src/expressions.ts
+++ b/packages/shadenfreude/src/expressions.ts
@@ -8,7 +8,7 @@ export type Expression = {
 
 const zip = (a: TemplateStringsArray, b: any[]) => a.map((k, i) => [k, b[i]])
 
-export const expr = (
+export const code = (
   strings: TemplateStringsArray,
   ...values: any[]
 ): Expression => ({

--- a/packages/shadenfreude/src/expressions.ts
+++ b/packages/shadenfreude/src/expressions.ts
@@ -14,7 +14,7 @@ const zip = (a: TemplateStringsArray, b: any[]) => a.map((k, i) => [k, b[i]])
 export const expr = <T extends GLSLType>(
   strings: TemplateStringsArray,
   ...values: any[]
-): ValueFunction<T> => {
+): ValueFunction => {
   collectedDependencies.push(...values)
 
   return () =>

--- a/packages/shadenfreude/src/expressions.ts
+++ b/packages/shadenfreude/src/expressions.ts
@@ -1,4 +1,5 @@
 import { glslRepresentation } from "./glslRepresentation"
+import { Float } from "./variables"
 
 export type Expression = {
   _: "Expression"
@@ -25,3 +26,8 @@ export const expr = (
 export function isExpression(v: any): v is Expression {
   return v && v._ === "Expression"
 }
+
+/* Type expression helpers */
+
+export const float = (strings: TemplateStringsArray, ...values: any[]) =>
+  Float(expr(strings, ...values))

--- a/packages/shadenfreude/src/glslRepresentation.ts
+++ b/packages/shadenfreude/src/glslRepresentation.ts
@@ -1,10 +1,11 @@
 import { Color, Vector2, Vector3, Vector4 } from "three"
+import { isExpression } from "./expressions"
 import { isSnippet } from "./lib/concatenator3000"
 import { isVariable, Value } from "./variables"
 
 export const glslRepresentation = (value: Value): string => {
   if (isVariable(value)) return value._config.name
-  if (typeof value === "function") return value()
+  if (isExpression(value)) return value.render()
   if (isSnippet(value)) return value.name
 
   if (typeof value === "string") return value

--- a/packages/shadenfreude/src/glslRepresentation.ts
+++ b/packages/shadenfreude/src/glslRepresentation.ts
@@ -1,11 +1,10 @@
 import { Color, Vector2, Vector3, Vector4 } from "three"
-import { Expression } from "./expressions"
-import { isExpression, isSnippet } from "./lib/concatenator3000"
+import { isSnippet } from "./lib/concatenator3000"
 import { isVariable, Value } from "./variables"
 
-export const glslRepresentation = (value: Value | Expression): string => {
+export const glslRepresentation = (value: Value): string => {
   if (isVariable(value)) return value._config.name
-  if (isExpression(value)) return value.render()
+  if (typeof value === "function") return value()
   if (isSnippet(value)) return value.name
 
   if (typeof value === "string") return value

--- a/packages/shadenfreude/src/glslRepresentation.ts
+++ b/packages/shadenfreude/src/glslRepresentation.ts
@@ -1,10 +1,12 @@
 import { Color, Vector2, Vector3, Vector4 } from "three"
-import { isExpression } from "./lib/concatenator3000"
-import { Expression, isVariable, Value } from "./variables"
+import { Expression } from "./expressions"
+import { isExpression, isSnippet } from "./lib/concatenator3000"
+import { isVariable, Value } from "./variables"
 
 export const glslRepresentation = (value: Value | Expression): string => {
   if (isVariable(value)) return value._config.name
   if (isExpression(value)) return value.render()
+  if (isSnippet(value)) return value.name
 
   if (typeof value === "string") return value
 

--- a/packages/shadenfreude/src/lib/__snapshots__/concatenator3000.test.ts.snap
+++ b/packages/shadenfreude/src/lib/__snapshots__/concatenator3000.test.ts.snap
@@ -4,9 +4,9 @@ exports[`snippet creates a snippet with a rendered chunk 1`] = `
 Object {
   "_": "Snippet",
   "chunk": Array [
-    "/*** SNIPPET: snippet_b117418551e1b8d4b59f6c1e18105f25177e09509cd53bdfc6f76de146877259 ***/",
-    "/* hi from snippet_b117418551e1b8d4b59f6c1e18105f25177e09509cd53bdfc6f76de146877259 */",
+    "/*** SNIPPET: snippet_b117418551 ***/",
+    "/* hi from snippet_b117418551 */",
   ],
-  "name": "snippet_b117418551e1b8d4b59f6c1e18105f25177e09509cd53bdfc6f76de146877259",
+  "name": "snippet_b117418551",
 }
 `;

--- a/packages/shadenfreude/src/lib/__snapshots__/concatenator3000.test.ts.snap
+++ b/packages/shadenfreude/src/lib/__snapshots__/concatenator3000.test.ts.snap
@@ -9,6 +9,5 @@ Object {
   ],
   "dependencies": Array [],
   "name": "snippet_b117418551e1b8d4b59f6c1e18105f25177e09509cd53bdfc6f76de146877259",
-  "toString": [Function],
 }
 `;

--- a/packages/shadenfreude/src/lib/__snapshots__/concatenator3000.test.ts.snap
+++ b/packages/shadenfreude/src/lib/__snapshots__/concatenator3000.test.ts.snap
@@ -3,10 +3,7 @@
 exports[`snippet creates a snippet with a rendered chunk 1`] = `
 Object {
   "_": "Snippet",
-  "chunk": Array [
-    "/*** SNIPPET: snippet_b117418551 ***/",
-    "/* hi from snippet_b117418551 */",
-  ],
+  "chunk": "/* hi from snippet_b117418551 */",
   "name": "snippet_b117418551",
 }
 `;

--- a/packages/shadenfreude/src/lib/__snapshots__/concatenator3000.test.ts.snap
+++ b/packages/shadenfreude/src/lib/__snapshots__/concatenator3000.test.ts.snap
@@ -7,7 +7,6 @@ Object {
     "/*** SNIPPET: snippet_b117418551e1b8d4b59f6c1e18105f25177e09509cd53bdfc6f76de146877259 ***/",
     "/* hi from snippet_b117418551e1b8d4b59f6c1e18105f25177e09509cd53bdfc6f76de146877259 */",
   ],
-  "dependencies": Array [],
   "name": "snippet_b117418551e1b8d4b59f6c1e18105f25177e09509cd53bdfc6f76de146877259",
 }
 `;

--- a/packages/shadenfreude/src/lib/concatenator3000.test.ts
+++ b/packages/shadenfreude/src/lib/concatenator3000.test.ts
@@ -62,14 +62,14 @@ describe("snippet", () => {
     const [shader] = compileShader(f)
 
     expect(shader.vertexShader).toMatchInlineSnapshot(`
-      "/*** SNIPPET: snippet_7dd01b876ac51c46f2484f6773fa837250a0197f2f0ff0533ac7373df8cf6ab9 ***/
-      float snippet_7dd01b876ac51c46f2484f6773fa837250a0197f2f0ff0533ac7373df8cf6ab9(float a, float b) { return a + b; }
+      "/*** SNIPPET: snippet_7dd01b876a ***/
+      float snippet_7dd01b876a(float a, float b) { return a + b; }
       void main()
       {
         /*** BEGIN: anon (1) ***/
         float float_anon_1;
         {
-          float value = snippet_7dd01b876ac51c46f2484f6773fa837250a0197f2f0ff0533ac7373df8cf6ab9(1, snippet_7dd01b876ac51c46f2484f6773fa837250a0197f2f0ff0533ac7373df8cf6ab9(2, 3));
+          float value = snippet_7dd01b876a(1, snippet_7dd01b876a(2, 3));
           float_anon_1 = value;
         }
         /*** END: anon (1) ***/
@@ -92,16 +92,16 @@ describe("snippet", () => {
     const [shader] = compileShader(f)
 
     expect(shader.vertexShader).toMatchInlineSnapshot(`
-      "/*** SNIPPET: snippet_3853dce07c2b5e268e8dfd14015417672771c0f7ffdb9d946747dfb86656afba ***/
-      float snippet_3853dce07c2b5e268e8dfd14015417672771c0f7ffdb9d946747dfb86656afba(float a, float b) { return a * b; }
-      /*** SNIPPET: snippet_9670319365a5bf2e01a7c10af84a990eb71f98161426bb28ba0ea23843a656ff ***/
-      float snippet_9670319365a5bf2e01a7c10af84a990eb71f98161426bb28ba0ea23843a656ff(float a, float b) { return a + snippet_3853dce07c2b5e268e8dfd14015417672771c0f7ffdb9d946747dfb86656afba(a, b); }
+      "/*** SNIPPET: snippet_3853dce07c ***/
+      float snippet_3853dce07c(float a, float b) { return a * b; }
+      /*** SNIPPET: snippet_98a183b64b ***/
+      float snippet_98a183b64b(float a, float b) { return a + snippet_3853dce07c(a, b); }
       void main()
       {
         /*** BEGIN: anon (1) ***/
         float float_anon_1;
         {
-          float value = snippet_9670319365a5bf2e01a7c10af84a990eb71f98161426bb28ba0ea23843a656ff(1, snippet_9670319365a5bf2e01a7c10af84a990eb71f98161426bb28ba0ea23843a656ff(2, 3));
+          float value = snippet_98a183b64b(1, snippet_98a183b64b(2, 3));
           float_anon_1 = value;
         }
         /*** END: anon (1) ***/

--- a/packages/shadenfreude/src/lib/concatenator3000.test.ts
+++ b/packages/shadenfreude/src/lib/concatenator3000.test.ts
@@ -31,21 +31,15 @@ describe("concatenate", () => {
 describe("snippet", () => {
   it("creates a Snippet with a unique name", () => {
     const s = snippet(() => "/* code */")
-    expect(s.name).toEqual(
-      "snippet_a996254afd1b407b9a44d2758225d5d208faa14c6e5b839596b3cdd8313dcbcb"
-    )
+    expect(s.name).toEqual("snippet_a996254afd")
   })
 
   it("will generate the same snippet IDs for the same contents", () => {
     let code = "/* code */"
     const s1 = snippet(() => code)
     const s2 = snippet(() => code)
-    expect(s1.name).toEqual(
-      "snippet_a996254afd1b407b9a44d2758225d5d208faa14c6e5b839596b3cdd8313dcbcb"
-    )
-    expect(s2.name).toEqual(
-      "snippet_a996254afd1b407b9a44d2758225d5d208faa14c6e5b839596b3cdd8313dcbcb"
-    )
+    expect(s1.name).toEqual("snippet_a996254afd")
+    expect(s2.name).toEqual("snippet_a996254afd")
   })
 
   it("creates a snippet with a rendered chunk", () => {

--- a/packages/shadenfreude/src/lib/concatenator3000.test.ts
+++ b/packages/shadenfreude/src/lib/concatenator3000.test.ts
@@ -1,5 +1,5 @@
 import { compileShader } from "../compilers"
-import { expr } from "../expressions"
+import { code } from "../expressions"
 import { Float } from "../variables"
 import { concatenate, flatten, snippet } from "./concatenator3000"
 
@@ -52,7 +52,7 @@ describe("snippet", () => {
       (name) => `float ${name}(float a, float b) { return a + b; }`
     )
 
-    const f = Float(expr`${add}(1, ${add}(2, 3))`)
+    const f = Float(code`${add}(1, ${add}(2, 3))`)
     const [shader] = compileShader(f)
 
     expect(shader.vertexShader).toMatchInlineSnapshot(`
@@ -79,10 +79,10 @@ describe("snippet", () => {
 
     const add = snippet(
       (name) =>
-        expr`float ${name}(float a, float b) { return a + ${mul}(a, b); }`
+        code`float ${name}(float a, float b) { return a + ${mul}(a, b); }`
     )
 
-    const f = Float(expr`${add}(1, ${add}(2, 3))`)
+    const f = Float(code`${add}(1, ${add}(2, 3))`)
     const [shader] = compileShader(f)
 
     expect(shader.vertexShader).toMatchInlineSnapshot(`

--- a/packages/shadenfreude/src/lib/concatenator3000.ts
+++ b/packages/shadenfreude/src/lib/concatenator3000.ts
@@ -1,4 +1,5 @@
 import sha256 from "crypto-js/sha256"
+import { isExpression } from "../expressions"
 
 export type Part = any
 
@@ -8,7 +9,7 @@ const compact = (p: any) => !!p
 
 const indent = (p: string) => "  " + p
 
-const renderFunctions = (v: any) => (typeof v === "function" ? v() : v)
+const renderExpressions = (v: any) => (isExpression(v) ? v.render() : v)
 
 export const block = (...parts: Parts): Parts => {
   const flattened = flatten(parts)
@@ -21,7 +22,7 @@ export const line = (...parts: Parts) => flatten(...parts).join(" ")
 
 export const flatten = (...parts: Parts): Parts =>
   parts
-    .map(renderFunctions)
+    .map(renderExpressions)
     .filter(compact)
     .map((p) => (Array.isArray(p) ? flatten(...p) : p))
     .flat()

--- a/packages/shadenfreude/src/lib/concatenator3000.ts
+++ b/packages/shadenfreude/src/lib/concatenator3000.ts
@@ -59,8 +59,12 @@ export type Snippet = {
 }
 
 export const snippet = (render: (name: string) => Part | Parts[]): Snippet => {
-  const hash = sha256(concatenate(render(""))).toString()
+  const hash = sha256(concatenate(render("")))
+    .toString()
+    .substring(0, 10)
+
   const name = identifier("snippet", hash)
+
   const chunk = flatten(`/*** SNIPPET: ${name} ***/`, render(name))
 
   return {

--- a/packages/shadenfreude/src/lib/concatenator3000.ts
+++ b/packages/shadenfreude/src/lib/concatenator3000.ts
@@ -1,5 +1,4 @@
 import sha256 from "crypto-js/sha256"
-import { Expression } from "../expressions"
 
 export type Part = any
 
@@ -9,7 +8,7 @@ const compact = (p: any) => !!p
 
 const indent = (p: string) => "  " + p
 
-const renderExpressions = (v: any) => (isExpression(v) ? v.render() : v)
+const renderFunctions = (v: any) => (typeof v === "function" ? v() : v)
 
 export const block = (...parts: Parts): Parts => {
   const flattened = flatten(parts)
@@ -22,7 +21,7 @@ export const line = (...parts: Parts) => flatten(...parts).join(" ")
 
 export const flatten = (...parts: Parts): Parts =>
   parts
-    .map(renderExpressions)
+    .map(renderFunctions)
     .filter(compact)
     .map((p) => (Array.isArray(p) ? flatten(...p) : p))
     .flat()
@@ -73,8 +72,4 @@ export const snippet = (render: (name: string) => Part | Parts[]): Snippet => {
 
 export function isSnippet(v: any): v is Snippet {
   return v && v._ === "Snippet"
-}
-
-export function isExpression(v: any): v is Expression {
-  return v && v._ === "Expression"
 }

--- a/packages/shadenfreude/src/lib/concatenator3000.ts
+++ b/packages/shadenfreude/src/lib/concatenator3000.ts
@@ -65,7 +65,6 @@ export type Snippet = {
   name: string
   chunk: Part | Part[]
   dependencies: Snippet[]
-  toString: () => string
 }
 
 export const snippet = (
@@ -75,7 +74,7 @@ export const snippet = (
   const hash = sha256(concatenate(render(""))).toString()
   const name = identifier("snippet", hash)
   const chunk = flatten(`/*** SNIPPET: ${name} ***/`, render(name))
-  return { _: "Snippet", name, chunk, dependencies, toString: () => name }
+  return { _: "Snippet", name, chunk, dependencies }
 }
 
 export function isSnippet(v: any): v is Snippet {

--- a/packages/shadenfreude/src/lib/concatenator3000.ts
+++ b/packages/shadenfreude/src/lib/concatenator3000.ts
@@ -57,13 +57,9 @@ export type Snippet = {
   _: "Snippet"
   name: string
   chunk: Part | Part[]
-  dependencies: Snippet[]
 }
 
-export const snippet = (
-  render: (name: string) => Part | Parts[],
-  dependencies: Snippet[] = []
-): Snippet => {
+export const snippet = (render: (name: string) => Part | Parts[]): Snippet => {
   const hash = sha256(concatenate(render(""))).toString()
   const name = identifier("snippet", hash)
   const chunk = flatten(`/*** SNIPPET: ${name} ***/`, render(name))
@@ -71,8 +67,7 @@ export const snippet = (
   return {
     _: "Snippet",
     name,
-    chunk,
-    dependencies
+    chunk
   }
 }
 

--- a/packages/shadenfreude/src/lib/concatenator3000.ts
+++ b/packages/shadenfreude/src/lib/concatenator3000.ts
@@ -1,10 +1,6 @@
 import sha256 from "crypto-js/sha256"
 import { Expression } from "../expressions"
 
-export const resetConcatenator3000 = () => {
-  seenSnippets.clear()
-}
-
 export type Part = any
 
 export type Parts = Part[]
@@ -26,7 +22,6 @@ export const line = (...parts: Parts) => flatten(...parts).join(" ")
 
 export const flatten = (...parts: Parts): Parts =>
   parts
-    .map(renderSnippets)
     .map(renderExpressions)
     .filter(compact)
     .map((p) => (Array.isArray(p) ? flatten(...p) : p))
@@ -58,8 +53,6 @@ export const sluggify = (s: string) =>
 
 /*** Snippets ***/
 
-const seenSnippets = new Set<string>()
-
 export type Snippet = {
   _: "Snippet"
   name: string
@@ -74,7 +67,13 @@ export const snippet = (
   const hash = sha256(concatenate(render(""))).toString()
   const name = identifier("snippet", hash)
   const chunk = flatten(`/*** SNIPPET: ${name} ***/`, render(name))
-  return { _: "Snippet", name, chunk, dependencies }
+
+  return {
+    _: "Snippet",
+    name,
+    chunk,
+    dependencies
+  }
 }
 
 export function isSnippet(v: any): v is Snippet {
@@ -84,12 +83,3 @@ export function isSnippet(v: any): v is Snippet {
 export function isExpression(v: any): v is Expression {
   return v && v._ === "Expression"
 }
-
-const renderSnippet = (s: Snippet): Part | Part[] => {
-  if (seenSnippets.has(s.name)) return
-  seenSnippets.add(s.name)
-
-  return [s.dependencies.map(renderSnippet), s.chunk]
-}
-
-const renderSnippets = (p: any) => (isSnippet(p) ? renderSnippet(p) : p)

--- a/packages/shadenfreude/src/lib/concatenator3000.ts
+++ b/packages/shadenfreude/src/lib/concatenator3000.ts
@@ -66,7 +66,7 @@ export const snippet = (render: (name: string) => Part | Parts[]): Snippet => {
 
   const name = identifier("snippet", hash)
 
-  const chunk = flatten(`/*** SNIPPET: ${name} ***/`, render(name))
+  const chunk = render(name)
 
   return {
     _: "Snippet",

--- a/packages/shadenfreude/src/nodes/geometry.ts
+++ b/packages/shadenfreude/src/nodes/geometry.ts
@@ -1,13 +1,13 @@
 import { Vector2 } from "three"
-import { expr } from "../expressions"
+import { code } from "../expressions"
 import { Mat4, Vec2, Vec3 } from "../variables"
 
-export const UV = Vec2(expr`uv`, { varying: true })
-export const VertexPosition = Vec3(expr`position`, { varying: true })
-export const VertexNormal = Vec3(expr`normal`, { varying: true })
-export const ViewMatrix = Mat4(expr`viewMatrix`, { varying: true })
-export const ModelMatrix = Mat4(expr`modelMatrix`, { varying: true })
-export const InstanceMatrix = Mat4(expr`instanceMatrix`, { varying: true })
+export const UV = Vec2(code`uv`, { varying: true })
+export const VertexPosition = Vec3(code`position`, { varying: true })
+export const VertexNormal = Vec3(code`normal`, { varying: true })
+export const ViewMatrix = Mat4(code`viewMatrix`, { varying: true })
+export const ModelMatrix = Mat4(code`modelMatrix`, { varying: true })
+export const InstanceMatrix = Mat4(code`instanceMatrix`, { varying: true })
 
 /*
 Now variables like VertexNormalWorld can just source those and work
@@ -15,7 +15,7 @@ in both shader stages:
 */
 
 export const VertexNormalWorld = Vec3(
-  expr`normalize(
+  code`normalize(
       mat3(
         ${ModelMatrix}[0].xyz,
         ${ModelMatrix}[1].xyz,
@@ -25,7 +25,7 @@ export const VertexNormalWorld = Vec3(
 )
 
 export const ViewDirection = Vec3(
-  expr`vec3(-${ViewMatrix}[0][2], -${ViewMatrix}[1][2], -${ViewMatrix}[2][2])`,
+  code`vec3(-${ViewMatrix}[0][2], -${ViewMatrix}[1][2], -${ViewMatrix}[2][2])`,
   { varying: true }
 )
 
@@ -35,7 +35,7 @@ export const TilingUV = (
   offset: Vec2 = new Vector2(0, 0)
 ) =>
   Vec2(
-    expr`vec2(
+    code`vec2(
       ${uv}.x * ${tiling}.x + ${offset}.x,
       ${uv}.y * ${tiling}.y + ${offset}.y)`
   )

--- a/packages/shadenfreude/src/nodes/geometry.ts
+++ b/packages/shadenfreude/src/nodes/geometry.ts
@@ -2,12 +2,12 @@ import { Vector2 } from "three"
 import { expr } from "../expressions"
 import { Mat4, Vec2, Vec3 } from "../variables"
 
-export const UV = Vec2("uv", { varying: true })
-export const VertexPosition = Vec3("position", { varying: true })
-export const VertexNormal = Vec3("normal", { varying: true })
-export const ViewMatrix = Mat4("viewMatrix", { varying: true })
-export const ModelMatrix = Mat4("modelMatrix", { varying: true })
-export const InstanceMatrix = Mat4("instanceMatrix", { varying: true })
+export const UV = Vec2(expr`uv`, { varying: true })
+export const VertexPosition = Vec3(expr`position`, { varying: true })
+export const VertexNormal = Vec3(expr`normal`, { varying: true })
+export const ViewMatrix = Mat4(expr`viewMatrix`, { varying: true })
+export const ModelMatrix = Mat4(expr`modelMatrix`, { varying: true })
+export const InstanceMatrix = Mat4(expr`instanceMatrix`, { varying: true })
 
 /*
 Now variables like VertexNormalWorld can just source those and work

--- a/packages/shadenfreude/src/nodes/helpers.test.ts
+++ b/packages/shadenfreude/src/nodes/helpers.test.ts
@@ -16,13 +16,29 @@ describe("Pipe", () => {
     expect(shader.vertexShader).toMatchInlineSnapshot(`
       "void main()
       {
-        /*** BEGIN: Multiply (float) (1) ***/
-        float float_Multiply_float_1;
+        /*** BEGIN: anon (1) ***/
+        float float_anon_1;
         {
-          float value = m_0*m_1;
-          float_Multiply_float_1 = value;
+          float value = 1.0;
+          float_anon_1 = value;
         }
-        /*** END: Multiply (float) (1) ***/
+        /*** END: anon (1) ***/
+
+        /*** BEGIN: Add (float) (2) ***/
+        float float_Add_float_2;
+        {
+          float value = float_anon_1 + 1.0;
+          float_Add_float_2 = value;
+        }
+        /*** END: Add (float) (2) ***/
+
+        /*** BEGIN: Multiply (float) (3) ***/
+        float float_Multiply_float_3;
+        {
+          float value = float_Add_float_2 * 5.0;
+          float_Multiply_float_3 = value;
+        }
+        /*** END: Multiply (float) (3) ***/
 
       }"
     `)

--- a/packages/shadenfreude/src/nodes/inputs.ts
+++ b/packages/shadenfreude/src/nodes/inputs.ts
@@ -1,8 +1,8 @@
-import { expr } from "../expressions"
+import { code } from "../expressions"
 import { Bool, Float, GLSLType, Variable } from "../variables"
 
 export const Uniform = <T extends GLSLType>(type: T, name: string) =>
-  Variable<T>(type, expr`${name}`, {
+  Variable<T>(type, code`${name}`, {
     title: `Uniform: ${name}`,
     vertexHeader: `uniform ${type} ${name};`,
     fragmentHeader: `uniform ${type} ${name};`
@@ -20,4 +20,4 @@ export const Time = Uniform("float", "u_time")
 export const Resolution = Uniform("vec2", "u_resolution")
 
 const Attribute = <T extends GLSLType>(type: T, name: string) =>
-  Variable(type, expr`${name}`, { varying: true })
+  Variable(type, code`${name}`, { varying: true })

--- a/packages/shadenfreude/src/nodes/inputs.ts
+++ b/packages/shadenfreude/src/nodes/inputs.ts
@@ -1,7 +1,8 @@
+import { expr } from "../expressions"
 import { Bool, Float, GLSLType, Variable } from "../variables"
 
 export const Uniform = <T extends GLSLType>(type: T, name: string) =>
-  Variable<T>(type, name, {
+  Variable<T>(type, expr`${name}`, {
     title: `Uniform: ${name}`,
     vertexHeader: `uniform ${type} ${name};`,
     fragmentHeader: `uniform ${type} ${name};`
@@ -19,4 +20,4 @@ export const Time = Uniform("float", "u_time")
 export const Resolution = Uniform("vec2", "u_resolution")
 
 const Attribute = <T extends GLSLType>(type: T, name: string) =>
-  Variable(type, name, { varying: true })
+  Variable(type, expr`${name}`, { varying: true })

--- a/packages/shadenfreude/src/nodes/masters.ts
+++ b/packages/shadenfreude/src/nodes/masters.ts
@@ -1,5 +1,5 @@
 import { Color } from "three"
-import { expr } from "../expressions"
+import { code } from "../expressions"
 import { Bool, Float, Vec3 } from "../variables"
 import { VertexPosition } from "./geometry"
 
@@ -16,6 +16,6 @@ export const CustomShaderMaterialMaster = ({
 }: CustomShaderMaterialMasterprops = {}) =>
   Bool(true, {
     title: "CustomShaderMaterial Master",
-    vertexBody: expr`csm_Position = ${position};`,
-    fragmentBody: expr`csm_DiffuseColor = vec4(${diffuseColor}, ${alpha});`
+    vertexBody: code`csm_Position = ${position};`,
+    fragmentBody: code`csm_DiffuseColor = vec4(${diffuseColor}, ${alpha});`
   })

--- a/packages/shadenfreude/src/nodes/math.ts
+++ b/packages/shadenfreude/src/nodes/math.ts
@@ -22,6 +22,7 @@ export const Divide = Operator("Divide", "/")
 
 export const Sin = (x: Float) => Float(expr`sin(${x})`)
 export const Cos = (x: Float) => Float(expr`cos(${x})`)
+export const Pow = (x: Float, y: Float) => Float(expr`pow(${x}, ${y})`)
 
 export const Mix = <T extends GLSLType>(a: Value<T>, b: Value<T>, f: Float) =>
   Variable(type(a), expr`mix(${a}, ${b}, ${f})`)
@@ -82,9 +83,5 @@ export const Remap = <T extends "float" | "vec2" | "vec3" | "vec4">(
 ) =>
   Variable(
     type(v),
-    expr`${remap}(${v}, ${inMin}, ${inMax}, ${outMin}, ${outMax})`,
-    {
-      vertexHeader: [remap],
-      fragmentHeader: [remap]
-    }
+    expr`${remap}(${v}, ${inMin}, ${inMax}, ${outMin}, ${outMax})`
   )

--- a/packages/shadenfreude/src/nodes/math.ts
+++ b/packages/shadenfreude/src/nodes/math.ts
@@ -4,23 +4,14 @@ import { snippet } from "../lib/concatenator3000"
 import { Float, GLSLType, Value, Variable } from "../variables"
 import { VertexNormalWorld, ViewDirection } from "./geometry"
 
-const buildMultiInputs = (values: Value[]) =>
-  values.reduce((acc, v, i) => ({ ...acc, [`m_${i}`]: v }), {})
-
 export const Operator = (title: string, operator: "+" | "-" | "*" | "/") => <
   T extends GLSLType
 >(
   a: Value<T>,
-  ...rest: Value[]
+  b: Value<any>
 ) => {
-  const inputs = buildMultiInputs([a, ...rest])
-
-  /* a + b + c + ... */
-  const expression = Object.keys(inputs).join(operator)
-
-  return Variable(type(a), expression, {
-    title: `${title} (${type(a)})`,
-    inputs
+  return Variable(type(a), expr`${a} ${operator} ${b}`, {
+    title: `${title} (${type(a)})`
   })
 }
 
@@ -29,11 +20,11 @@ export const Subtract = Operator("Subtract", "-")
 export const Multiply = Operator("Multiply", "*")
 export const Divide = Operator("Divide", "/")
 
-export const Sin = (x: Float) => Float("sin(x)", { inputs: { x } })
-export const Cos = (x: Float) => Float("cos(x)", { inputs: { x } })
+export const Sin = (x: Float) => Float(expr`sin(${x})`)
+export const Cos = (x: Float) => Float(expr`cos(${x})`)
 
 export const Mix = <T extends GLSLType>(a: Value<T>, b: Value<T>, f: Float) =>
-  Variable(type(a), "mix(a, b, f)", { inputs: { a, b, f } })
+  Variable(type(a), expr`mix(${a}, ${b}, ${f})`)
 
 export type FresnelProps = {
   alpha?: Float

--- a/packages/shadenfreude/src/nodes/math.ts
+++ b/packages/shadenfreude/src/nodes/math.ts
@@ -20,6 +20,10 @@ export const Subtract = Operator("Subtract", "-")
 export const Multiply = Operator("Multiply", "*")
 export const Divide = Operator("Divide", "/")
 
+export const Sub = Subtract
+export const Mul = Multiply
+export const Div = Divide
+
 export const Sin = (x: Float) => Float(expr`sin(${x})`)
 export const Cos = (x: Float) => Float(expr`cos(${x})`)
 export const Pow = (x: Float, y: Float) => Float(expr`pow(${x}, ${y})`)

--- a/packages/shadenfreude/src/nodes/math.ts
+++ b/packages/shadenfreude/src/nodes/math.ts
@@ -35,25 +35,15 @@ export type FresnelProps = {
 }
 
 export const Fresnel = ({
-  alpha = 1,
   bias = 0,
   intensity = 1,
   power = 2,
   factor = 1
 }: FresnelProps = {}) =>
   Float(0, {
-    inputs: {
-      alpha,
-      bias,
-      intensity,
-      power,
-      factor,
-      ViewDirection,
-      normal: VertexNormalWorld
-    },
-    fragmentBody: `
-      float f_a = (factor + dot(ViewDirection, normal));
-      float f_fresnel = bias + intensity * pow(abs(f_a), power);
+    fragmentBody: expr`
+      float f_a = (${factor} + dot(${ViewDirection}, ${VertexNormalWorld}));
+      float f_fresnel = ${bias} + ${intensity} * pow(abs(f_a), ${power});
       f_fresnel = clamp(f_fresnel, 0.0, 1.0);
       value = f_fresnel;
     `

--- a/packages/shadenfreude/src/nodes/math.ts
+++ b/packages/shadenfreude/src/nodes/math.ts
@@ -1,4 +1,4 @@
-import { expr } from "../expressions"
+import { code } from "../expressions"
 import { type } from "../glslType"
 import { snippet } from "../lib/concatenator3000"
 import { Float, GLSLType, Value, Variable } from "../variables"
@@ -10,7 +10,7 @@ export const Operator = (title: string, operator: "+" | "-" | "*" | "/") => <
   a: Value<T>,
   b: Value<any>
 ) => {
-  return Variable(type(a), expr`${a} ${operator} ${b}`, {
+  return Variable(type(a), code`${a} ${operator} ${b}`, {
     title: `${title} (${type(a)})`
   })
 }
@@ -24,12 +24,12 @@ export const Sub = Subtract
 export const Mul = Multiply
 export const Div = Divide
 
-export const Sin = (x: Float) => Float(expr`sin(${x})`)
-export const Cos = (x: Float) => Float(expr`cos(${x})`)
-export const Pow = (x: Float, y: Float) => Float(expr`pow(${x}, ${y})`)
+export const Sin = (x: Float) => Float(code`sin(${x})`)
+export const Cos = (x: Float) => Float(code`cos(${x})`)
+export const Pow = (x: Float, y: Float) => Float(code`pow(${x}, ${y})`)
 
 export const Mix = <T extends GLSLType>(a: Value<T>, b: Value<T>, f: Float) =>
-  Variable(type(a), expr`mix(${a}, ${b}, ${f})`)
+  Variable(type(a), code`mix(${a}, ${b}, ${f})`)
 
 export type FresnelProps = {
   alpha?: Float
@@ -46,7 +46,7 @@ export const Fresnel = ({
   factor = 1
 }: FresnelProps = {}) =>
   Float(0, {
-    fragmentBody: expr`
+    fragmentBody: code`
       float f_a = (${factor} + dot(${ViewDirection}, ${VertexNormalWorld}));
       float f_fresnel = ${bias} + ${intensity} * pow(abs(f_a), ${power});
       f_fresnel = clamp(f_fresnel, 0.0, 1.0);
@@ -54,10 +54,10 @@ export const Fresnel = ({
     `
   })
 
-export const Step = (edge: Float, v: Float) => Float(expr`step(${edge}, ${v})`)
+export const Step = (edge: Float, v: Float) => Float(code`step(${edge}, ${v})`)
 
 export const Smoothstep = (min: Float, max: Float, v: Float) =>
-  Float(expr`smoothstep(${min}, ${max}, ${v})`)
+  Float(code`smoothstep(${min}, ${max}, ${v})`)
 
 const remap = snippet(
   (name) => `
@@ -87,5 +87,5 @@ export const Remap = <T extends "float" | "vec2" | "vec3" | "vec4">(
 ) =>
   Variable(
     type(v),
-    expr`${remap}(${v}, ${inMin}, ${inMax}, ${outMin}, ${outMax})`
+    code`${remap}(${v}, ${inMin}, ${inMax}, ${outMin}, ${outMax})`
   )

--- a/packages/shadenfreude/src/nodes/noise/PerlinNoise.ts
+++ b/packages/shadenfreude/src/nodes/noise/PerlinNoise.ts
@@ -1,3 +1,4 @@
+import { expr } from "../../expressions"
 import { snippet } from "../../lib/concatenator3000"
 import { Vec3, Float } from "../../variables"
 import { mod289 } from "./mod289"
@@ -5,8 +6,7 @@ import { permute } from "./permute"
 import { taylorInvSqrt } from "./taylorInvSqrt"
 
 export const PerlinNoise = (p: Vec3, rep: Vec3) =>
-  Float(`${noise.name}(p, rep)`, {
-    inputs: { p, rep },
+  Float(expr`${noise.name}(${p}, ${rep})`, {
     vertexHeader: [noise],
     fragmentHeader: [noise]
   })

--- a/packages/shadenfreude/src/nodes/noise/PerlinNoise.ts
+++ b/packages/shadenfreude/src/nodes/noise/PerlinNoise.ts
@@ -33,7 +33,7 @@ const fade = snippet(
 
 const noise = snippet(
   (name) =>
-    `
+    expr`
     // Classic Perlin noise, periodic variant
     float ${name}(vec3 P, vec3 rep)
     {
@@ -103,6 +103,5 @@ const noise = snippet(
       float n_xyz = mix(n_yz.x, n_yz.y, fade_xyz.x);
       return 2.2 * n_xyz;
     }
-  `,
-  [mod289, permute, taylorInvSqrt, fade]
+  `
 )

--- a/packages/shadenfreude/src/nodes/noise/PerlinNoise.ts
+++ b/packages/shadenfreude/src/nodes/noise/PerlinNoise.ts
@@ -1,4 +1,4 @@
-import { expr } from "../../expressions"
+import { code } from "../../expressions"
 import { snippet } from "../../lib/concatenator3000"
 import { Vec3, Float } from "../../variables"
 import { mod289 } from "./mod289"
@@ -6,7 +6,7 @@ import { permute } from "./permute"
 import { taylorInvSqrt } from "./taylorInvSqrt"
 
 export const PerlinNoise = (p: Vec3, rep: Vec3) =>
-  Float(expr`${noise.name}(${p}, ${rep})`, {
+  Float(code`${noise.name}(${p}, ${rep})`, {
     vertexHeader: [noise],
     fragmentHeader: [noise]
   })
@@ -33,7 +33,7 @@ const fade = snippet(
 
 const noise = snippet(
   (name) =>
-    expr`
+    code`
     // Classic Perlin noise, periodic variant
     float ${name}(vec3 P, vec3 rep)
     {

--- a/packages/shadenfreude/src/nodes/noise/Simplex3DNoise.ts
+++ b/packages/shadenfreude/src/nodes/noise/Simplex3DNoise.ts
@@ -1,10 +1,10 @@
-import { expr } from "../../expressions"
+import { expr, float } from "../../expressions"
 import { snippet } from "../../lib/concatenator3000"
 import { Vec3, Float } from "../../variables"
 import { permute } from "./permute"
 import { taylorInvSqrt } from "./taylorInvSqrt"
 
-export const Simplex3DNoise = (p: Vec3) => Float(expr`${noise}(${p})`)
+export const Simplex3DNoise = (p: Vec3) => float`${noise}(${p})`
 
 const noise = snippet(
   (name) => expr`

--- a/packages/shadenfreude/src/nodes/noise/Simplex3DNoise.ts
+++ b/packages/shadenfreude/src/nodes/noise/Simplex3DNoise.ts
@@ -1,13 +1,13 @@
-import { expr } from "../../expressions"
+import { code } from "../../expressions"
 import { snippet } from "../../lib/concatenator3000"
 import { Vec3, Float } from "../../variables"
 import { permute } from "./permute"
 import { taylorInvSqrt } from "./taylorInvSqrt"
 
-export const Simplex3DNoise = (p: Vec3) => Float(expr`${noise}(${p})`)
+export const Simplex3DNoise = (p: Vec3) => Float(code`${noise}(${p})`)
 
 const noise = snippet(
-  (name) => expr`
+  (name) => code`
 
 float ${name}(vec3 v){
   const vec2  C = vec2(1.0/6.0, 1.0/3.0) ;

--- a/packages/shadenfreude/src/nodes/noise/Simplex3DNoise.ts
+++ b/packages/shadenfreude/src/nodes/noise/Simplex3DNoise.ts
@@ -1,11 +1,11 @@
+import { expr } from "../../expressions"
 import { snippet } from "../../lib/concatenator3000"
 import { Vec3, Float } from "../../variables"
 import { permute } from "./permute"
 import { taylorInvSqrt } from "./taylorInvSqrt"
 
 export const Simplex3DNoise = (p: Vec3) =>
-  Float(`${noise.name}(p)`, {
-    inputs: { p },
+  Float(expr`${noise.name}(${p})`, {
     vertexHeader: [noise],
     fragmentHeader: [noise]
   })

--- a/packages/shadenfreude/src/nodes/noise/Simplex3DNoise.ts
+++ b/packages/shadenfreude/src/nodes/noise/Simplex3DNoise.ts
@@ -1,10 +1,10 @@
-import { expr, float } from "../../expressions"
+import { expr } from "../../expressions"
 import { snippet } from "../../lib/concatenator3000"
 import { Vec3, Float } from "../../variables"
 import { permute } from "./permute"
 import { taylorInvSqrt } from "./taylorInvSqrt"
 
-export const Simplex3DNoise = (p: Vec3) => float`${noise}(${p})`
+export const Simplex3DNoise = (p: Vec3) => Float(expr`${noise}(${p})`)
 
 const noise = snippet(
   (name) => expr`

--- a/packages/shadenfreude/src/nodes/noise/Simplex3DNoise.ts
+++ b/packages/shadenfreude/src/nodes/noise/Simplex3DNoise.ts
@@ -4,14 +4,10 @@ import { Vec3, Float } from "../../variables"
 import { permute } from "./permute"
 import { taylorInvSqrt } from "./taylorInvSqrt"
 
-export const Simplex3DNoise = (p: Vec3) =>
-  Float(expr`${noise.name}(${p})`, {
-    vertexHeader: [noise],
-    fragmentHeader: [noise]
-  })
+export const Simplex3DNoise = (p: Vec3) => Float(expr`${noise}(${p})`)
 
 const noise = snippet(
-  (name) => `
+  (name) => expr`
 
 float ${name}(vec3 v){
   const vec2  C = vec2(1.0/6.0, 1.0/3.0) ;
@@ -81,6 +77,5 @@ float ${name}(vec3 v){
   return 42.0 * dot( m*m, vec4( dot(p0,x0), dot(p1,x1),
                                 dot(p2,x2), dot(p3,x3) ) );
 }
-`,
-  [taylorInvSqrt, permute]
+`
 )

--- a/packages/shadenfreude/src/nodes/noise/permute.ts
+++ b/packages/shadenfreude/src/nodes/noise/permute.ts
@@ -1,14 +1,13 @@
+import { expr } from "../../expressions"
 import { snippet } from "../../lib/concatenator3000"
 import { mod289 } from "./mod289"
 
 export const permute = snippet(
-  (name) => [
-    `
+  (name) =>
+    expr`
     vec4 ${name}(vec4 x)
     {
-      return ${mod289.name}(((x*34.0)+10.0)*x);
+      return ${mod289}(((x*34.0)+10.0)*x);
     }
   `
-  ],
-  [mod289]
 )

--- a/packages/shadenfreude/src/nodes/noise/permute.ts
+++ b/packages/shadenfreude/src/nodes/noise/permute.ts
@@ -1,10 +1,10 @@
-import { expr } from "../../expressions"
+import { code } from "../../expressions"
 import { snippet } from "../../lib/concatenator3000"
 import { mod289 } from "./mod289"
 
 export const permute = snippet(
   (name) =>
-    expr`
+    code`
     vec4 ${name}(vec4 x)
     {
       return ${mod289}(((x*34.0)+10.0)*x);

--- a/packages/shadenfreude/src/nodes/vectors.test.ts
+++ b/packages/shadenfreude/src/nodes/vectors.test.ts
@@ -1,7 +1,7 @@
 import { Vector2, Vector3, Vector4 } from "three"
 import { glslRepresentation } from "../glslRepresentation"
 import { Float } from "../variables"
-import { Join, Split } from "./vectors"
+import { Join, Split, Split2, SplitVector3, SplitVector4 } from "./vectors"
 
 describe("Join", () => {
   it("creates a vec2 variable from two components", () => {
@@ -25,21 +25,21 @@ describe("Join", () => {
 
 describe("Split", () => {
   it("splits a vec2 into two components", () => {
-    const [a, b] = Split(new Vector2(1, 2))
+    const [a, b] = Split2(new Vector2(1, 2))
 
     expect(a.type).toBe("float")
     expect(b.type).toBe("float")
   })
 
   it("splits a vec3 into three components", () => {
-    const [a, b, c] = Split(new Vector3(1, 2, 3))
+    const [a, b, c] = SplitVector3(new Vector3(1, 2, 3))
     expect(a.type).toBe("float")
     expect(b.type).toBe("float")
     expect(c.type).toBe("float")
   })
 
   it("splits a vec4 into four components", () => {
-    const [a, b, c, d] = Split(new Vector4(1, 2, 3))
+    const [a, b, c, d] = SplitVector4(new Vector4(1, 2, 3))
     expect(a.type).toBe("float")
     expect(b.type).toBe("float")
     expect(c.type).toBe("float")

--- a/packages/shadenfreude/src/nodes/vectors.test.ts
+++ b/packages/shadenfreude/src/nodes/vectors.test.ts
@@ -1,7 +1,6 @@
 import { Vector2, Vector3, Vector4 } from "three"
 import { glslRepresentation } from "../glslRepresentation"
-import { Float } from "../variables"
-import { Join, Split, Split2, SplitVector3, SplitVector4 } from "./vectors"
+import { Join, SplitVector2, SplitVector3, SplitVector4 } from "./vectors"
 
 describe("Join", () => {
   it("creates a vec2 variable from two components", () => {
@@ -25,8 +24,7 @@ describe("Join", () => {
 
 describe("Split", () => {
   it("splits a vec2 into two components", () => {
-    const [a, b] = Split2(new Vector2(1, 2))
-
+    const [a, b] = SplitVector2(new Vector2(1, 2))
     expect(a.type).toBe("float")
     expect(b.type).toBe("float")
   })

--- a/packages/shadenfreude/src/nodes/vectors.test.ts
+++ b/packages/shadenfreude/src/nodes/vectors.test.ts
@@ -1,22 +1,29 @@
 import { Vector2, Vector3, Vector4 } from "three"
 import { glslRepresentation } from "../glslRepresentation"
-import { Join, SplitVector2, SplitVector3, SplitVector4 } from "./vectors"
+import {
+  JoinVector2,
+  JoinVector3,
+  JoinVector4,
+  SplitVector2,
+  SplitVector3,
+  SplitVector4
+} from "./vectors"
 
 describe("Join", () => {
   it("creates a vec2 variable from two components", () => {
-    const v = Join(1, 2)
+    const v = JoinVector2(1, 2)
     expect(v.type).toBe("vec2")
     expect(glslRepresentation(v.value)).toBe("vec2(1.0, 2.0)")
   })
 
   it("creates a vec3 variable from three components", () => {
-    const v = Join(1, 2, 3)
+    const v = JoinVector3(1, 2, 3)
     expect(v.type).toBe("vec3")
     expect(glslRepresentation(v.value)).toBe("vec3(1.0, 2.0, 3.0)")
   })
 
   it("creates a vec4 variable from three components", () => {
-    const v = Join(1, 2, 3, 4)
+    const v = JoinVector4(1, 2, 3, 4)
     expect(v.type).toBe("vec4")
     expect(glslRepresentation(v.value)).toBe("vec4(1.0, 2.0, 3.0, 4.0)")
   })

--- a/packages/shadenfreude/src/nodes/vectors.ts
+++ b/packages/shadenfreude/src/nodes/vectors.ts
@@ -2,35 +2,13 @@ import { expr } from "../expressions"
 import { type } from "../glslType"
 import { Float, Value, Variable, Vec2, Vec3, Vec4 } from "../variables"
 
-export type Vector2Components = [Float, Float]
-export type Vector3Components = [Float, Float, Float]
-export type Vector4Components = [Float, Float, Float, Float]
+export const JoinVector2 = (x: Float, y: Float) => Vec2(expr`vec2(${x}, ${y})`)
 
-export type JoinReturnType<Args> = Args extends Vector4Components
-  ? Variable<"vec4">
-  : Args extends Vector3Components
-  ? Variable<"vec3">
-  : Args extends Vector2Components
-  ? Variable<"vec2">
-  : never
+export const JoinVector3 = (x: Float, y: Float, z: Float) =>
+  Vec3(expr`vec3(${x}, ${y}, ${z})`)
 
-export const Join = <
-  Args extends Vector2Components | Vector3Components | Vector4Components
->(
-  ...args: Args
-) => {
-  const [x, y, z, w] = args
-
-  if (w !== undefined) {
-    return Vec4(expr`vec4(${x}, ${y}, ${z}, ${w})`) as JoinReturnType<Args>
-  }
-
-  if (z !== undefined) {
-    return Vec3(expr`vec3(${x}, ${y}, ${z})`) as JoinReturnType<Args>
-  }
-
-  return Vec2(expr`vec2(${x}, ${y})`) as JoinReturnType<Args>
-}
+export const JoinVector4 = (x: Float, y: Float, z: Float, w: Float) =>
+  Vec4(expr`vec4(${x}, ${y}, ${z}, ${w})`)
 
 export const SplitVector2 = (vector: Vec2) =>
   [Float(expr`${vector}.x`), Float(expr`${vector}.y`)] as const

--- a/packages/shadenfreude/src/nodes/vectors.ts
+++ b/packages/shadenfreude/src/nodes/vectors.ts
@@ -1,32 +1,32 @@
-import { expr } from "../expressions"
+import { code } from "../expressions"
 import { type } from "../glslType"
 import { Float, Value, Variable, Vec2, Vec3, Vec4 } from "../variables"
 
-export const JoinVector2 = (x: Float, y: Float) => Vec2(expr`vec2(${x}, ${y})`)
+export const JoinVector2 = (x: Float, y: Float) => Vec2(code`vec2(${x}, ${y})`)
 
 export const JoinVector3 = (x: Float, y: Float, z: Float) =>
-  Vec3(expr`vec3(${x}, ${y}, ${z})`)
+  Vec3(code`vec3(${x}, ${y}, ${z})`)
 
 export const JoinVector4 = (x: Float, y: Float, z: Float, w: Float) =>
-  Vec4(expr`vec4(${x}, ${y}, ${z}, ${w})`)
+  Vec4(code`vec4(${x}, ${y}, ${z}, ${w})`)
 
 export const SplitVector2 = (vector: Vec2) =>
-  [Float(expr`${vector}.x`), Float(expr`${vector}.y`)] as const
+  [Float(code`${vector}.x`), Float(code`${vector}.y`)] as const
 
 export const SplitVector3 = (vector: Vec3) =>
   [
-    Float(expr`${vector}.x`),
-    Float(expr`${vector}.y`),
-    Float(expr`${vector}.z`)
+    Float(code`${vector}.x`),
+    Float(code`${vector}.y`),
+    Float(code`${vector}.z`)
   ] as const
 
 export const SplitVector4 = (vector: Vec4) =>
   [
-    Float(expr`${vector}.x`),
-    Float(expr`${vector}.y`),
-    Float(expr`${vector}.z`),
-    Float(expr`${vector}.w`)
+    Float(code`${vector}.x`),
+    Float(code`${vector}.y`),
+    Float(code`${vector}.z`),
+    Float(code`${vector}.w`)
   ] as const
 
 export const Normalize = <T extends "vec2" | "vec3" | "vec4">(x: Value<T>) =>
-  Variable(type(x) as T, expr`normalize(${x})`)
+  Variable(type(x) as T, code`normalize(${x})`)

--- a/packages/shadenfreude/src/nodes/vectors.ts
+++ b/packages/shadenfreude/src/nodes/vectors.ts
@@ -1,6 +1,6 @@
 import { expr } from "../expressions"
 import { type } from "../glslType"
-import { Float, isType, Value, Variable, Vec2, Vec3, Vec4 } from "../variables"
+import { Float, Value, Variable, Vec2, Vec3, Vec4 } from "../variables"
 
 export type Vector2Components = [Float, Float]
 export type Vector3Components = [Float, Float, Float]
@@ -49,23 +49,6 @@ export const SplitVector4 = (vector: Vec4) =>
     Float(expr`${vector}.z`),
     Float(expr`${vector}.w`)
   ] as const
-
-type VectorTypes = "vec2" | "vec3" | "vec4"
-
-type SplitVector<V extends Value<VectorTypes>> = V extends Vec4
-  ? [Float, Float, Float, Float]
-  : V extends Vec3
-  ? [Float, Float, Float]
-  : V extends Vec2
-  ? [Float, Float]
-  : never
-
-export const Split = <V extends Value<VectorTypes>>(vector: V) => {
-  if (isType(vector, "vec2")) return SplitVector2(vector) as SplitVector<V>
-  if (isType(vector, "vec3")) return SplitVector3(vector) as SplitVector<V>
-  if (isType(vector, "vec4")) return SplitVector4(vector) as SplitVector<V>
-  throw new Error("Could not split value: " + vector)
-}
 
 export const Normalize = <T extends "vec2" | "vec3" | "vec4">(x: Value<T>) =>
   Variable(type(x) as T, expr`normalize(${x})`)

--- a/packages/shadenfreude/src/variables.test.ts
+++ b/packages/shadenfreude/src/variables.test.ts
@@ -1,4 +1,5 @@
 import { compileShader } from "./compilers"
+import { expr } from "./expressions"
 import { glslRepresentation } from "./glslRepresentation"
 import { Bool, Float, Variable } from "./variables"
 
@@ -15,6 +16,12 @@ describe("variable", () => {
   it("supports string values (which will be used as verbatim expressions)", () => {
     const v = Variable("vec3", "vec3(1.0, 1.0, 1.0)")
     expect(glsl(v.value)).toBe("vec3(1.0, 1.0, 1.0)")
+  })
+
+  it("supports expression values", () => {
+    const a = Float(1)
+    const v = Variable("vec3", expr`vec3(${a}, 1.0, 1.0)`)
+    expect(glsl(v.value)).toBe(`vec3(${a._config.name}, 1.0, 1.0)`)
   })
 
   it("allows variables to directly reference other variables", () => {

--- a/packages/shadenfreude/src/variables.test.ts
+++ b/packages/shadenfreude/src/variables.test.ts
@@ -14,7 +14,7 @@ describe("variable", () => {
   })
 
   it("supports string values (which will be used as verbatim expressions)", () => {
-    const v = Variable("vec3", "vec3(1.0, 1.0, 1.0)")
+    const v = Variable("vec3", expr`vec3(1.0, 1.0, 1.0)`)
     expect(glsl(v.value)).toBe("vec3(1.0, 1.0, 1.0)")
   })
 
@@ -34,7 +34,7 @@ describe("variable", () => {
   it("supports a 'varying' flag that will automatically make it pass its data as a varying", () => {
     const v = Variable(
       "float",
-      "1.0 + 2.0 + onlyAvailableInVertex.x", // a value expression that can only work in a vertex shader
+      expr`1.0 + 2.0 + onlyAvailableInVertex.x`, // a value expression that can only work in a vertex shader
       {
         title: "A variable with a varying",
         varying: true,
@@ -54,9 +54,9 @@ describe("variable", () => {
     expect(glsl(v.value)).toBe("(1.0) * 2.0")
   })
 
-  it("constructor functions can pass string values to other variables", () => {
+  it("constructor functions can pass string values as expressions", () => {
     const Double = (f: Value<"float">) => Float(expr`(${f}) * 2.0`)
-    const v = Double("5.0")
+    const v = Double(expr`5.0`)
     expect(glsl(v.value)).toBe(`(5.0) * 2.0`)
   })
 

--- a/packages/shadenfreude/src/variables.test.ts
+++ b/packages/shadenfreude/src/variables.test.ts
@@ -49,21 +49,28 @@ describe("variable", () => {
   })
 
   it("supports constructing variables through constructor functions", () => {
-    const Double = (f: Value<"float">) => Float(expr`${f} * 2.0`)
+    const Double = (f: Value<"float">) => Float(expr`(${f}) * 2.0`)
     const v = Double(1)
-    expect(glsl(v.value)).toBe("1.0 * 2.0")
+    expect(glsl(v.value)).toBe("(1.0) * 2.0")
   })
 
   it("constructor functions can pass string values to other variables", () => {
-    const Double = (f: Value<"float">) => Float(expr`${f} * 2.0`)
+    const Double = (f: Value<"float">) => Float(expr`(${f}) * 2.0`)
     const v = Double("5.0")
-    expect(glsl(v.value)).toBe(`5.0 * 2.0`)
+    expect(glsl(v.value)).toBe(`(5.0) * 2.0`)
   })
 
   it("constructor functions can pass references to other variables", () => {
-    const Double = (f: Value<"float">) => Float(expr`${f} * 2.0`)
+    const Double = (f: Value<"float">) => Float(expr`(${f}) * 2.0`)
     const a = Float(1)
     const v = Double(a)
-    expect(glsl(v.value)).toBe(`${a._config.name} * 2.0`)
+    expect(glsl(v.value)).toBe(`(${a._config.name}) * 2.0`)
+  })
+
+  it("constructor functions can pass expression values to other variables", () => {
+    const Double = (f: Value<"float">) => Float(expr`(${f}) * 2.0`)
+    const a = Float(5)
+    const v = Double(expr`${a} + 5.0`)
+    expect(glsl(v.value)).toBe(`(${a._config.name} + 5.0) * 2.0`)
   })
 })

--- a/packages/shadenfreude/src/variables.test.ts
+++ b/packages/shadenfreude/src/variables.test.ts
@@ -1,7 +1,7 @@
 import { compileShader } from "./compilers"
 import { expr } from "./expressions"
 import { glslRepresentation } from "./glslRepresentation"
-import { Bool, Float, Variable } from "./variables"
+import { Float, Value, Variable } from "./variables"
 
 const glsl = glslRepresentation
 
@@ -46,5 +46,18 @@ describe("variable", () => {
 
     expect(c.vertexShader).toMatchSnapshot()
     expect(c.fragmentShader).toMatchSnapshot()
+  })
+
+  it("supports constructing variables through constructor functions", () => {
+    const Double = (f: Value<"float">) => Float(expr`${f} * 2.0`)
+    const v = Double(1)
+    expect(glsl(v.value)).toBe("1.0 * 2.0")
+  })
+
+  it("constructor functions can pass references to other variables", () => {
+    const Double = (f: Value<"float">) => Float(expr`${f} * 2.0`)
+    const a = Float(1)
+    const v = Double(a)
+    expect(glsl(v.value)).toBe(`${a._config.name} * 2.0`)
   })
 })

--- a/packages/shadenfreude/src/variables.test.ts
+++ b/packages/shadenfreude/src/variables.test.ts
@@ -47,8 +47,4 @@ describe("variable", () => {
     expect(c.vertexShader).toMatchSnapshot()
     expect(c.fragmentShader).toMatchSnapshot()
   })
-
-  it("provides a mechanism for variables to declare functions", () => {
-    const v = Bool(true, {})
-  })
 })

--- a/packages/shadenfreude/src/variables.test.ts
+++ b/packages/shadenfreude/src/variables.test.ts
@@ -54,6 +54,12 @@ describe("variable", () => {
     expect(glsl(v.value)).toBe("1.0 * 2.0")
   })
 
+  it("constructor functions can pass string values to other variables", () => {
+    const Double = (f: Value<"float">) => Float(expr`${f} * 2.0`)
+    const v = Double("5.0")
+    expect(glsl(v.value)).toBe(`5.0 * 2.0`)
+  })
+
   it("constructor functions can pass references to other variables", () => {
     const Double = (f: Value<"float">) => Float(expr`${f} * 2.0`)
     const a = Float(1)

--- a/packages/shadenfreude/src/variables.test.ts
+++ b/packages/shadenfreude/src/variables.test.ts
@@ -1,5 +1,5 @@
 import { compileShader } from "./compilers"
-import { expr } from "./expressions"
+import { code } from "./expressions"
 import { glslRepresentation } from "./glslRepresentation"
 import { Float, Value, Variable } from "./variables"
 
@@ -14,13 +14,13 @@ describe("variable", () => {
   })
 
   it("supports string values (which will be used as verbatim expressions)", () => {
-    const v = Variable("vec3", expr`vec3(1.0, 1.0, 1.0)`)
+    const v = Variable("vec3", code`vec3(1.0, 1.0, 1.0)`)
     expect(glsl(v.value)).toBe("vec3(1.0, 1.0, 1.0)")
   })
 
   it("supports expression values", () => {
     const a = Float(1)
-    const v = Variable("vec3", expr`vec3(${a}, 1.0, 1.0)`)
+    const v = Variable("vec3", code`vec3(${a}, 1.0, 1.0)`)
     expect(glsl(v.value)).toBe(`vec3(${a._config.name}, 1.0, 1.0)`)
   })
 
@@ -34,7 +34,7 @@ describe("variable", () => {
   it("supports a 'varying' flag that will automatically make it pass its data as a varying", () => {
     const v = Variable(
       "float",
-      expr`1.0 + 2.0 + onlyAvailableInVertex.x`, // a value expression that can only work in a vertex shader
+      code`1.0 + 2.0 + onlyAvailableInVertex.x`, // a value expression that can only work in a vertex shader
       {
         title: "A variable with a varying",
         varying: true,
@@ -49,28 +49,28 @@ describe("variable", () => {
   })
 
   it("supports constructing variables through constructor functions", () => {
-    const Double = (f: Value<"float">) => Float(expr`(${f}) * 2.0`)
+    const Double = (f: Value<"float">) => Float(code`(${f}) * 2.0`)
     const v = Double(1)
     expect(glsl(v.value)).toBe("(1.0) * 2.0")
   })
 
   it("constructor functions can pass string values as expressions", () => {
-    const Double = (f: Value<"float">) => Float(expr`(${f}) * 2.0`)
-    const v = Double(expr`5.0`)
+    const Double = (f: Value<"float">) => Float(code`(${f}) * 2.0`)
+    const v = Double(code`5.0`)
     expect(glsl(v.value)).toBe(`(5.0) * 2.0`)
   })
 
   it("constructor functions can pass references to other variables", () => {
-    const Double = (f: Value<"float">) => Float(expr`(${f}) * 2.0`)
+    const Double = (f: Value<"float">) => Float(code`(${f}) * 2.0`)
     const a = Float(1)
     const v = Double(a)
     expect(glsl(v.value)).toBe(`(${a._config.name}) * 2.0`)
   })
 
   it("constructor functions can pass expression values to other variables", () => {
-    const Double = (f: Value<"float">) => Float(expr`(${f}) * 2.0`)
+    const Double = (f: Value<"float">) => Float(code`(${f}) * 2.0`)
     const a = Float(5)
-    const v = Double(expr`${a} + 5.0`)
+    const v = Double(code`${a} + 5.0`)
     expect(glsl(v.value)).toBe(`(${a._config.name} + 5.0) * 2.0`)
   })
 })

--- a/packages/shadenfreude/src/variables.ts
+++ b/packages/shadenfreude/src/variables.ts
@@ -1,5 +1,5 @@
 import { Color, Matrix3, Matrix4, Vector2, Vector3, Vector4 } from "three"
-import { flushDependencies } from "./expressions"
+import { Expression } from "./expressions"
 import { type } from "./glslType"
 import { identifier, Part, Snippet } from "./lib/concatenator3000"
 import idGenerator from "./lib/idGenerator"
@@ -23,11 +23,9 @@ export type JSTypes = {
   mat4: Matrix4
 }
 
-export type ValueFunction = () => Part | Part[]
-
 export type Value<T extends GLSLType = any> =
   | string
-  | ValueFunction
+  | Expression
   | JSTypes[T]
   | Variable<T>
 
@@ -37,7 +35,6 @@ export type VariableConfig<T extends GLSLType = any> = {
   id: number
   title: string
   name: string
-  dependencies: (Variable | Snippet)[]
   only?: "vertex" | "fragment"
   varying?: boolean
   vertexHeader?: Chunk
@@ -76,7 +73,6 @@ export const Variable = <T extends GLSLType>(
     id,
     title: "anon",
     name: identifier("anonymous", id),
-    dependencies: flushDependencies(),
 
     /* User-provided configuration */
     ...configInput

--- a/packages/shadenfreude/src/variables.ts
+++ b/packages/shadenfreude/src/variables.ts
@@ -4,6 +4,9 @@ import { type } from "./glslType"
 import { identifier, Part, Snippet } from "./lib/concatenator3000"
 import idGenerator from "./lib/idGenerator"
 
+/**
+ * The different GLSL types we're supporting in variables.
+ */
 export type GLSLType =
   | "bool"
   | "float"
@@ -90,10 +93,6 @@ export const Variable = <T extends GLSLType>(
 
 export function isVariable(v: any): v is Variable {
   return v && v._ === "Variable"
-}
-
-export function isType<T extends GLSLType>(v: any, t: T): v is Value<T> {
-  return type(v) === t
 }
 
 /* Helpers */

--- a/packages/shadenfreude/src/variables.ts
+++ b/packages/shadenfreude/src/variables.ts
@@ -1,5 +1,5 @@
 import { Color, Matrix3, Matrix4, Vector2, Vector3, Vector4 } from "three"
-import { Expression, flushDependencies } from "./expressions"
+import { flushDependencies } from "./expressions"
 import { type } from "./glslType"
 import { identifier, Part, Snippet } from "./lib/concatenator3000"
 import idGenerator from "./lib/idGenerator"
@@ -23,9 +23,11 @@ export type JSTypes = {
   mat4: Matrix4
 }
 
+export type ValueFunction<T extends GLSLType> = (v: Value<T>) => Part | Part[]
+
 export type Value<T extends GLSLType = any> =
   | string
-  | Expression
+  | ValueFunction<T>
   | JSTypes[T]
   | Variable<T>
 

--- a/packages/shadenfreude/src/variables.ts
+++ b/packages/shadenfreude/src/variables.ts
@@ -64,6 +64,15 @@ export type Variable<
 
 const nextAnonymousId = idGenerator()
 
+/**
+ * Create a variable. Variables are the nodes the shader tree is composed of. Everything in the tree
+ * is expressed as a variable.
+ *
+ * @param type GLSL type of the variable.
+ * @param value Value of the variable. Can be a JS value, a reference to another variable, or a string expression.
+ * @param configInput Optional configuration object.
+ * @returns A freshly created variable, just for you
+ */
 export const Variable = <T extends GLSLType>(
   type: T,
   value: Value<T>,

--- a/packages/shadenfreude/src/variables.ts
+++ b/packages/shadenfreude/src/variables.ts
@@ -26,7 +26,6 @@ export type JSTypes = {
 }
 
 export type Value<T extends GLSLType = any> =
-  | string
   | Expression
   | JSTypes[T]
   | Variable<T>

--- a/packages/shadenfreude/src/variables.ts
+++ b/packages/shadenfreude/src/variables.ts
@@ -23,11 +23,11 @@ export type JSTypes = {
   mat4: Matrix4
 }
 
-export type ValueFunction<T extends GLSLType> = (v: Value<T>) => Part | Part[]
+export type ValueFunction = () => Part | Part[]
 
 export type Value<T extends GLSLType = any> =
   | string
-  | ValueFunction<T>
+  | ValueFunction
   | JSTypes[T]
   | Variable<T>
 

--- a/packages/shadenfreude/src/variables.ts
+++ b/packages/shadenfreude/src/variables.ts
@@ -1,7 +1,7 @@
 import { Color, Matrix3, Matrix4, Vector2, Vector3, Vector4 } from "three"
 import { Expression, flushDependencies } from "./expressions"
 import { type } from "./glslType"
-import { identifier, Part } from "./lib/concatenator3000"
+import { identifier, Part, Snippet } from "./lib/concatenator3000"
 import idGenerator from "./lib/idGenerator"
 
 export type GLSLType =
@@ -35,7 +35,7 @@ export type VariableConfig<T extends GLSLType = any> = {
   id: number
   title: string
   name: string
-  dependencies: Variable[]
+  dependencies: (Variable | Snippet)[]
   only?: "vertex" | "fragment"
   varying?: boolean
   vertexHeader?: Chunk

--- a/packages/shadenfreude/src/variables.ts
+++ b/packages/shadenfreude/src/variables.ts
@@ -1,7 +1,6 @@
 import { Color, Matrix3, Matrix4, Vector2, Vector3, Vector4 } from "three"
 import { Expression } from "./expressions"
-import { type } from "./glslType"
-import { identifier, Part, Snippet } from "./lib/concatenator3000"
+import { identifier, Part } from "./lib/concatenator3000"
 import idGenerator from "./lib/idGenerator"
 
 /**


### PR DESCRIPTION
Big new feature!

- No more manual declaration of `inputs`.
- Instead, use `expr` tagged template literals anywhere you are consuming an outside dependency.

```js
const a = Float(1)
const b = Float(2)

return Float(expr`${a} + ${b}`)
``` 

### Checklist

- [x] Remove `inputs`
- [x] Remove code generating local input variables, it is no longer needed
- [x] Implement `expr` (name TBD); have it return an `Expression` object that contains:
  - [x] The actual rendered string expression (see snippet below)
  - [x] A list of extracted dependencies
- [x] Have the compiler check if the value is an `Expression`; if so, use it to follow dependencies
- [x] Fix/reimplement math nodes
- [x] Make it work for snippets, too
- [x] Move seen snippet tracking from concatenator3000 to compiler
- [x] Decide on the final name for `expr`
- [x] Play with `float`, `vec3` etc. helpers ;-)
- [x] Remove `values` from `Expression`, it is no longer needed
- [x] Resolve dependencies when compiling, not when constructing
- [x] Resolve expression dependencies of expressions ```Simplex3DNoise(expr`${VertexPosition}`)```